### PR TITLE
Add rhsm option & update source repo if it already exists

### DIFF
--- a/roles/setup_server/tasks/main.yaml
+++ b/roles/setup_server/tasks/main.yaml
@@ -85,5 +85,6 @@
     type: "{{ custom_repo_type | default(omit) }}"
     check_ssl: "{{ custom_repo_check_ssl | default(omit) }}"
     check_gpg: "{{ custom_repo_check_gpg | default(omit) }}"
-    gpgkey_urls: "{{ gpgkey_urls | default(omit) }}"
+    gpgkey_urls: "{{ custom_repo_gpgkey_urls | default(omit) }}"
+    rhsm: "{{ custom_repo_rhsm | default(omit) }}"
     state: "{{ custom_repo_state }}"


### PR DESCRIPTION
Add rhsm option & update source repo if it already exists

Weldr api doesn't have an update endpoint for sources, I'm deleting the source and adding a new source in order to make a change. This is what is done when using composer-cli or cockpit image builder.