### PR TITLE
Add Role to Create 'edge-installer' Type Images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,7 @@ dmypy.json
 .pyre/
 
 context/
+
+# inventory/vars for testing
+testing.inventory.yml
+testing.extra-vars.yml

--- a/ee-requirements.yml
+++ b/ee-requirements.yml
@@ -3,3 +3,4 @@ collections:
   - community.general
   - ansible.posix
   - git+https://github.com/redhat-cop/infra.osbuild.git
+  - containers.podman

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -20,6 +20,7 @@ authors:
   - Adam Miller (@maxamillion)
   - Chris Santiago (@resoluteCoder)
   - Matthew Sandoval (@matoval)
+  - Josh Swanson (@jjaswanson4)
 
 ### OPTIONAL but strongly recommended
 
@@ -46,6 +47,7 @@ tags: []
 dependencies:
   "community.general": ">1.0.0"
   "ansible.posix": ">1.0.0"
+  "containers.podman": "*"
 
 # The URL of the originating SCM repository
 repository: https://github.com/redhat-cop/infra.osbuild

--- a/playbooks/build_edge_installer.yml
+++ b/playbooks/build_edge_installer.yml
@@ -1,0 +1,8 @@
+---
+
+- name: Run osbuild_builder role
+  become: true
+  hosts:
+    - all
+  roles:
+    - infra.osbuild.build_edge_installer

--- a/roles/build_edge_installer/defaults/main.yml
+++ b/roles/build_edge_installer/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for builder

--- a/roles/build_edge_installer/handlers/main.yml
+++ b/roles/build_edge_installer/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for builder

--- a/roles/build_edge_installer/meta/main.yml
+++ b/roles/build_edge_installer/meta/main.yml
@@ -1,0 +1,22 @@
+---
+galaxy_info:
+  role_name: "builder"
+  standalone: false
+  company: "Red Hat"
+  description: "Build an edge installer type image using osbuild composer"
+  author: Ansible Edge Working Group
+  license: "GPL-3.0-or-later"
+  min_ansible_version: "2.12"
+  platforms:
+    - name: "EL"
+      versions:
+        - "8"
+        - "9"
+    - name: "Fedora"
+      versions:
+        - "all"
+  galaxy_tags:
+    - "image"
+    - "build"
+    - "os"
+dependencies: []

--- a/roles/build_edge_installer/tasks/build-edge-container.yml
+++ b/roles/build_edge_installer/tasks/build-edge-container.yml
@@ -1,0 +1,34 @@
+---
+
+- name: Create a blueprint
+  infra.osbuild.create_blueprint:
+    dest: "{{ builder_blueprint_src_path }}"
+    name: "{{ builder_blueprint_name }}"
+    packages: "{{ builder_compose_pkgs }}"
+    customizations: "{{ builder_compose_customizations }}"
+  register: blueprint_output
+
+- name: Push the blueprint into image builder
+  infra.osbuild.push_blueprint:
+    src: "{{ builder_blueprint_src_path }}"
+
+- name: Start compose
+  infra.osbuild.start_compose:
+    blueprint: "{{ builder_blueprint_name }}"
+    compose_type: "{{ builder_compose_type }}"
+  register: compose_start_out
+
+- name: Wait for compose to finish
+  infra.osbuild.wait_compose:
+    compose_id: "{{ compose_start_out['result']['build_id'] }}"
+
+- name: Create tmp directory for blueprint
+  ansible.builtin.file:
+    path: "/tmp/{{ builder_blueprint_name }}"
+    mode: 0755
+    state: directory
+
+- name: Export the compose artifact
+  infra.osbuild.export_compose:
+    compose_id: "{{ compose_start_out['result']['build_id'] }}"
+    dest: "/tmp/{{ builder_blueprint_name }}/{{ builder_blueprint_name }}-{{ blueprint_output['current_version'] }}.{{ compose_start_out['result']['output_type'] }}" 

--- a/roles/build_edge_installer/tasks/build-edge-installer.yml
+++ b/roles/build_edge_installer/tasks/build-edge-installer.yml
@@ -1,0 +1,33 @@
+---
+
+- name: Create a blueprint
+  infra.osbuild.create_blueprint:
+    dest: "{{ builder_blueprint_src_path }}-installer"
+    name: "{{ builder_blueprint_name }}-installer"
+  register: blueprint_output
+
+- name: Push the blueprint into image builder
+  infra.osbuild.push_blueprint:
+    src: "{{ builder_blueprint_src_path }}-installer"
+
+- name: Start compose
+  infra.osbuild.start_compose:
+    blueprint: "{{ builder_blueprint_name }}-installer"
+    compose_type: "edge-installer"
+    ostree_url: "http://{{ ansible_default_ipv4.address }}:8080/repo"
+  register: compose_start_out
+
+- name: Wait for compose to finish
+  infra.osbuild.wait_compose:
+    compose_id: "{{ compose_start_out['result']['build_id'] }}"
+
+- name: Create tmp directory for blueprint
+  ansible.builtin.file:
+    path: "/tmp/{{ builder_blueprint_name }}-installer"
+    mode: 0755
+    state: directory
+
+- name: Export the compose artifact
+  infra.osbuild.export_compose:
+    compose_id: "{{ compose_start_out['result']['build_id'] }}"
+    dest: "/tmp/{{ builder_blueprint_name }}-installer/{{ builder_blueprint_name }}-{{ blueprint_output['current_version'] }}.{{ compose_start_out['result']['output_type'] }}" 

--- a/roles/build_edge_installer/tasks/main.yml
+++ b/roles/build_edge_installer/tasks/main.yml
@@ -1,5 +1,8 @@
 ---
 
+- name: import pre-flight tasks
+  ansible.builtin.import_tasks: pre-flight.yml
+
 - name: import tasks to build edge-container
   ansible.builtin.import_tasks: build-edge-container.yml
 
@@ -8,3 +11,6 @@
 
 - name: import tasks to build edge-installer
   ansible.builtin.import_tasks: build-edge-installer.yml
+
+- name: import post-flight tasks
+  ansible.builtin.import_tasks: post-flight.yml

--- a/roles/build_edge_installer/tasks/main.yml
+++ b/roles/build_edge_installer/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+
+- name: import tasks to build edge-container
+  ansible.builtin.import_tasks: build-edge-container.yml
+
+- name: import tasks to run edge-container
+  ansible.builtin.import_tasks: run-edge-container.yml
+
+- name: import tasks to build edge-installer
+  ansible.builtin.import_tasks: build-edge-installer.yml

--- a/roles/build_edge_installer/tasks/post-flight.yml
+++ b/roles/build_edge_installer/tasks/post-flight.yml
@@ -1,0 +1,11 @@
+---
+
+- name: cleanup edge-container
+  containers.podman.podman_container:
+    name: "{{ builder_blueprint_name }}-container"
+    state: absent
+
+- name: cleanup edge-container iamge
+  containers.podman.podman_image:
+    name: "localhost/{{ builder_blueprint_name }}-container:{{ blueprint_output['current_version'] }}"
+    state: absent

--- a/roles/build_edge_installer/tasks/pre-flight.yml
+++ b/roles/build_edge_installer/tasks/pre-flight.yml
@@ -1,0 +1,6 @@
+---
+
+- name: ensure podman is present
+  ansible.builtin.dnf:
+    name:
+      - podman

--- a/roles/build_edge_installer/tasks/run-edge-container.yml
+++ b/roles/build_edge_installer/tasks/run-edge-container.yml
@@ -1,0 +1,26 @@
+---
+
+# podman_load module has a bug
+# - name: load in container image
+#   containers.podman.podman_load:
+#     input: "/tmp/{{ builder_blueprint_name }}/{{ builder_blueprint_name }}-{{ blueprint_output['current_version'] }}.{{ compose_start_out['result']['output_type'] }}"
+#   register: loaded_image
+
+- name: load in container image
+  ansible.builtin.shell:
+    cmd: cat /tmp/device-edge-manager/device-edge-manager-0.0.4.tar | podman load
+  register: loaded_image
+  changed_when: false
+
+- name: tag container image
+  containers.podman.podman_tag:
+    image: "{{ loaded_image.stdout_lines[0].split(' ')[2] }}"
+    target_names:
+      - "localhost/{{ builder_blueprint_name }}-container:{{ blueprint_output['current_version'] }}"
+
+- name: run edge container
+  containers.podman.podman_container:
+    name: "{{ builder_blueprint_name }}-container"
+    image:  "localhost/{{ builder_blueprint_name }}-container:{{ blueprint_output['current_version'] }}"
+    ports:
+      - 8080:8080

--- a/roles/build_edge_installer/tests/inventory
+++ b/roles/build_edge_installer/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/roles/build_edge_installer/tests/test.yml
+++ b/roles/build_edge_installer/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - build_edge_installer

--- a/roles/build_edge_installer/vars/main.yml
+++ b/roles/build_edge_installer/vars/main.yml
@@ -1,0 +1,18 @@
+---
+builder_blueprint_name: test_blueprint
+builder_blueprint_src_path: /tmp/blueprint.toml
+builder_blueprint_distro_lower: "{{ ansible_distribution if not 'RedHat' else 'rhel' | lower }}"
+builder_blueprint_ref: "{{ builder_blueprint_distro_lower }}/{{ hostvars[inventory_hostname].ansible_distribution_major_version }}/x86_64/edge"
+builder_compose_type: edge-commit
+builder_pub_key: "~/.ssh/id_rsa.pub"
+builder_compose_pkgs:
+  - "vim-enhanced"
+  - "git"
+  - "neovim"
+builder_compose_customizations:
+  user:
+    name: "core"
+    description: "test user"
+    password: "openshift"
+    key: "{{ builder_pub_key }}"
+    groups: '["users", "wheel"]'


### PR DESCRIPTION
This PR adds a role (and an example playbook playbook) for building edge-installer ISOs using the modules within the collection.

Since the workflow for building installer ISOs is: build edge-container --> run edge container --> build edge-installer from edge-container source, this role handles taking the "default" set of vars and creating both the edge-container and edge-installer.