### PR TITLE
Support Building Images on ostree-Based OSes

### DIFF
--- a/roles/setup_server/defaults/main.yml
+++ b/roles/setup_server/defaults/main.yml
@@ -17,3 +17,4 @@ base_packages:
   - httpd
   - syslinux
   - cockpit
+  - weldr-client

--- a/roles/setup_server/defaults/main.yml
+++ b/roles/setup_server/defaults/main.yml
@@ -5,7 +5,7 @@ custom_repo_type: yum-baseurl
 custom_repo_check_ssl: false
 custom_repo_check_gpg: false
 custom_repo_state: present
-_infra_osbuild_ostree_check: false
+_infra_osbuild_ostree_os: false
 base_packages:
   - rsync
   - osbuild-composer

--- a/roles/setup_server/defaults/main.yml
+++ b/roles/setup_server/defaults/main.yml
@@ -5,3 +5,15 @@ custom_repo_type: yum-baseurl
 custom_repo_check_ssl: false
 custom_repo_check_gpg: false
 custom_repo_state: present
+ostree_os: false
+base_packages:
+  - rsync
+  - osbuild-composer
+  - composer-cli
+  - cockpit-composer
+  - bash-completion
+  - firewalld
+  - genisoimage
+  - httpd
+  - syslinux
+  - cockpit

--- a/roles/setup_server/defaults/main.yml
+++ b/roles/setup_server/defaults/main.yml
@@ -5,7 +5,7 @@ custom_repo_type: yum-baseurl
 custom_repo_check_ssl: false
 custom_repo_check_gpg: false
 custom_repo_state: present
-ostree_os: false
+_infra_osbuild_ostree_check: false
 base_packages:
   - rsync
   - osbuild-composer

--- a/roles/setup_server/tasks/main.yaml
+++ b/roles/setup_server/tasks/main.yaml
@@ -72,17 +72,12 @@
     - name: ensure packages are present
       ansible.builtin.assert:
         that:
-          - '"rsync" in ansible_facts["packages"]'
-          - '"osbuild-composer" in ansible_facts["packages"]'
-          - '"weldr-client" in ansible_facts["packages"]'
-          - '"cockpit-composer" in ansible_facts["packages"]'
-          - '"bash-completion" in ansible_facts["packages"]'
-          - '"firewalld" in ansible_facts["packages"]'
-          - '"genisoimage" in ansible_facts["packages"]'
-          - '"httpd" in ansible_facts["packages"]'
-          - '"syslinux" in ansible_facts["packages"]'
-          - '"cockpit" in ansible_facts["packages"]'
-        fail_msg: "Cannot continue, ensure the following packages are present: {{ base_packages | flatten }}"
+          - '{{ package }} in ansible_facts["packages"]'
+        fail_msg: "Cannot continue, ensure that {{ package }} is present"
+      loop_control:
+        loop_var: package
+      loop:
+        - "{{ base_packages }}"
 
     - name: Ensure EL9/Fedora33 => packages are present
       ansible.builtin.assert:

--- a/roles/setup_server/tasks/main.yaml
+++ b/roles/setup_server/tasks/main.yaml
@@ -19,7 +19,7 @@
 
 - name: Non ostree-based OS specific setup
   when:
-    - not ostree_os
+    - not _infra_osbuild_ostree_os
   block:
     - name: Setup Repositories
       community.general.rhsm_repository:
@@ -44,7 +44,7 @@
     - ansible_distribution in ['RedHat', 'CentOS', 'Fedora']
     - ansible_distribution == 'Fedora' and ansible_distribution_major_version|int < 33 or
       ansible_distribution_major_version|int == 8
-    - not ostree_os
+    - not _infra_osbuild_ostree_os
   block:
     - name: Install pytoml
       ansible.builtin.dnf:
@@ -57,7 +57,7 @@
     - ansible_distribution in ['RedHat', 'CentOS', 'Fedora']
     - ansible_distribution == 'Fedora' and ansible_distribution_major_version|int > 32 or
       ansible_distribution_major_version|int == 9
-    - not ostree_os
+    - not _infra_osbuild_ostree_os
   block:
     - name: Install toml
       ansible.builtin.dnf:
@@ -67,7 +67,7 @@
 
 - name: Ostree-based OS checks
   when:
-    - ostree_os
+    - _infra_osbuild_ostree_os
   block:
     - name: ensure packages are present
       ansible.builtin.assert:

--- a/roles/setup_server/tasks/main.yaml
+++ b/roles/setup_server/tasks/main.yaml
@@ -6,16 +6,16 @@
 - name: Test for ostree-based OS
   ansible.builtin.shell:
     cmd: "rpm-ostree status | grep Deployments"
-  register: ostree_check
+  register: _infra_osbuild_ostree_check
   failed_when: false
   changed_when: false
   check_mode: false
 
 - name: set ostree-based OS fact
   ansible.builtin.set_fact:
-    ostree_os: true
+    _infra_osbuild_ostree_os: true
   when:
-    - ostree_check.rc | int == 0
+    - _infra_osbuild_ostree_check.rc | int == 0
 
 - name: Non ostree-based OS specific setup
   when:

--- a/roles/setup_server/tasks/main.yaml
+++ b/roles/setup_server/tasks/main.yaml
@@ -3,39 +3,48 @@
 - name: Get Package Facts
   ansible.builtin.package_facts:
 
-- name: Setup Repositories
-  community.general.rhsm_repository:
-    state: enabled
-    purge: true
-    name:
-      - "rhel-{{ ansible_distribution_major_version }}-for-x86_64-appstream-rpms"
-      - "rhel-{{ ansible_distribution_major_version }}-for-x86_64-baseos-rpms"
-  when:
-    - ansible_distribution == 'RedHat'
-    - '"rh-amazon-rhui-client" not in ansible_facts["packages"]'
-    - '"rhui-azure-rhel9" not in ansible_facts["packages"]'
-    - '"rhui-azure-rhel8" not in ansible_facts["packages"]'
+- name: Test for ostree-based OS
+  ansible.builtin.shell:
+    cmd: "rpm-ostree status | grep Deployments"
+  register: ostree_check
+  failed_when: false
+  changed_when: false
+  check_mode: false
 
-- name: Install Packages
-  ansible.builtin.dnf:
-    state: present
-    name:
-      - rsync
-      - osbuild-composer
-      - composer-cli
-      - cockpit-composer
-      - bash-completion
-      - firewalld
-      - genisoimage
-      - httpd
-      - syslinux
-      - cockpit
+- name: set ostree-based OS fact
+  ansible.builtin.set_fact:
+    ostree_os: true
+  when:
+    - ostree_check.rc | int == 0
+
+- name: Non ostree-based OS specific setup
+  when:
+    - not ostree_os
+  block:
+    - name: Setup Repositories
+      community.general.rhsm_repository:
+        state: enabled
+        purge: true
+        name:
+          - "rhel-{{ ansible_distribution_major_version }}-for-x86_64-appstream-rpms"
+          - "rhel-{{ ansible_distribution_major_version }}-for-x86_64-baseos-rpms"
+      when:
+        - ansible_distribution == 'RedHat'
+        - '"rh-amazon-rhui-client" not in ansible_facts["packages"]'
+        - '"rhui-azure-rhel9" not in ansible_facts["packages"]'
+        - '"rhui-azure-rhel8" not in ansible_facts["packages"]'
+
+    - name: Install Packages
+      ansible.builtin.dnf:
+        state: present
+        name: "{{ base_packages }}"
 
 - name: RHEL8, CentOS8 and Fedora32 =< specific setup
   when:
     - ansible_distribution in ['RedHat', 'CentOS', 'Fedora']
     - ansible_distribution == 'Fedora' and ansible_distribution_major_version|int < 33 or
       ansible_distribution_major_version|int == 8
+    - not ostree_os
   block:
     - name: Install pytoml
       ansible.builtin.dnf:
@@ -48,12 +57,54 @@
     - ansible_distribution in ['RedHat', 'CentOS', 'Fedora']
     - ansible_distribution == 'Fedora' and ansible_distribution_major_version|int > 32 or
       ansible_distribution_major_version|int == 9
+    - not ostree_os
   block:
     - name: Install toml
       ansible.builtin.dnf:
         state: present
         name:
           - python3-toml
+
+- name: Ostree-based OS checks
+  when:
+    - ostree_os
+  block:
+    - name: ensure packages are present
+      ansible.builtin.assert:
+        that:
+          - '"rsync" in ansible_facts["packages"]'
+          - '"osbuild-composer" in ansible_facts["packages"]'
+          - '"weldr-client" in ansible_facts["packages"]'
+          - '"cockpit-composer" in ansible_facts["packages"]'
+          - '"bash-completion" in ansible_facts["packages"]'
+          - '"firewalld" in ansible_facts["packages"]'
+          - '"genisoimage" in ansible_facts["packages"]'
+          - '"httpd" in ansible_facts["packages"]'
+          - '"syslinux" in ansible_facts["packages"]'
+          - '"cockpit" in ansible_facts["packages"]'
+        fail_msg: "Cannot continue, ensure the following packages are present: {{ base_packages | flatten }}"
+
+    - name: Ensure EL9/Fedora33 => packages are present
+      ansible.builtin.assert:
+        that:
+          - '"python3-toml" in ansible_facts["packages"]'
+        fail_msg: "Ensure python3-toml is present on EL9/Fedora33+ systems"
+
+      when:
+        - ansible_distribution in ['RedHat', 'CentOS', 'Fedora']
+        - ansible_distribution == 'Fedora' and ansible_distribution_major_version|int > 32 or
+          ansible_distribution_major_version|int == 9
+
+    - name: Ensure EL8/Fedora32 =< packages are present
+      ansible.builtin.assert:
+        that:
+          - '"python3-pytoml" in ansible_facts["packages"]'
+        fail_msg: "Ensure python3-pytoml is present on EL8/Fedora32- systems"
+      when:
+        - ansible_distribution in ['RedHat', 'CentOS', 'Fedora']
+        - ansible_distribution == 'Fedora' and ansible_distribution_major_version|int < 33 or
+          ansible_distribution_major_version|int == 8
+
 
 - name: Enable Cockpit/Composer/Firewalld/Apache
   ansible.builtin.systemd:


### PR DESCRIPTION
This PR modifies the `setup_server` role to handle being run against an ostree-based operating system.

ostree-based OSes can run image builder and can be used like any other rpm/etc-based OS for building images, assuming the prerequisite packages are included in the OS image.

This PR handles identifying an ostree-based OS, checks that all required packages are present, skips package installation steps, and warns the user if needed and subsequently fails out cleanly.