### PR TITLE
from isoinfo to blkid

### DIFF
--- a/plugins/modules/inject_ks.py
+++ b/plugins/modules/inject_ks.py
@@ -129,7 +129,7 @@ def main():
 
     # get binary paths
     ksvalidator = module.get_bin_path("ksvalidator")
-    isoinfo = module.get_bin_path("isoinfo")
+    blkid = module.get_bin_path("blkid")
     xorriso = module.get_bin_path("xorriso")
     mtype = module.get_bin_path("mtype")
     mcopy = module.get_bin_path("mcopy")
@@ -149,13 +149,13 @@ def main():
     ksvalidator_out = run_cmd(module, ksvalidator_cmd)
 
     # get ISO volume id
-    isovolid_cmd = [isoinfo, "-d", "-i", module.params["src_iso"]]
+    isovolid_cmd = [blkid, module.params["src_iso"]]
     isovolid_out = run_cmd(module, isovolid_cmd)
     try:
+
         isovolid = (
-            [line for line in isovolid_out.split("\n") if "Volume id:" in line][0]
-            .split(":")[-1]
-            .strip()
+          isovolid_out.split("=")[2].strip()
+          .split('"')[1]
         )
     except IndexError as e:
         module.fail_json(


### PR DESCRIPTION
I'm trying to inject a kickstart script with inject_ks.py in RHEL 9, but I've found that, even with the package `genisoimage` installed,  the command `isoinfo` is not in the system, so the playbook fails.

This is another way to get the ISO volume ID with  `blkid`  which is in RHEL 8 and 9
