### PR TITLE
remove err from run_cmd

### DIFF
--- a/plugins/modules/inject_ks.py
+++ b/plugins/modules/inject_ks.py
@@ -90,7 +90,7 @@ def run_cmd(module, cmd_list):
     lang_env = dict(LANG=locale, LC_ALL=locale, LC_MESSAGES=locale)
 
     rc, out, err = module.run_command(cmd_list, environ_update=lang_env)
-    if (rc != 0) or err:
+    if (rc != 0) :
         module.fail_json(
             "ERROR: Command '%s' failed with return code: %s and error message, '%s'"
             % (" ".join(cmd_list), rc, err)


### PR DESCRIPTION
The `/usr/bin/xorriso` command is returning an empty `err` string when using the Ansible module even when the command completes with success, so the playbook fails.

Probably there is a better way than removing checking if the err exist or not to make the playbook fail, but since still the return code check is in place, this could be a quick-and-dirty workaround