### PR TITLE
Remove aap defaults, conditionally create aap playbook in ks

### DIFF
--- a/roles/builder/README.md
+++ b/roles/builder/README.md
@@ -170,6 +170,19 @@ builder_compose_customizations:
     
 ```
 
+## Kickstart AAP Variables
+
+Define these variables to auto register the system with AAP
+
+Example: 
+```yaml
+builder_aap_url: 'https://<IP_ADDRESS>/api/v2/inventories/<INVENTORY_NUMBER>/hosts/'
+builder_set_hostname: "{% raw %}{{ ansible_default_ipv4.macaddress | replace(':','') }}{% endraw %}"
+builder_aap_ks_user: 'user1'
+builder_aap_ks_password: 'pass1'
+builder_set_variables: "{% raw %}{ipaddress: {{ ansible_all_ipv4_addresses }}, macaddress: '{{ ansible_default_ipv4.macaddress }}' }{% endraw %}"
+```
+
 ### builder_aap_url
 
 Type: string

--- a/roles/builder/defaults/main.yml
+++ b/roles/builder/defaults/main.yml
@@ -3,7 +3,7 @@ builder_blueprint_name: test_blueprint_aap
 builder_blueprint_src_path: /tmp/blueprint.toml
 builder_blueprint_distro_lower: "{{ 'rhel' if ansible_distribution == 'RedHat' else ansible_distribution | lower }}"
 builder_blueprint_ref: "{{ builder_blueprint_distro_lower }}/{{ hostvars[inventory_hostname].ansible_distribution_major_version }}/x86_64/{{ 'iot' if ansible_distribution == 'Fedora' else 'edge' }}" # noqa yaml[line-length]
-builder_compose_type: edge-installer
+builder_compose_type: edge-commit
 builder_pub_key: "{{ lookup('file', '~/.ssh/id_rsa.pub') }}"
 builder_compose_pkgs:
   - "vim-enhanced"
@@ -16,8 +16,3 @@ builder_compose_customizations:
     password: "openshift"
     key: "{{ builder_pub_key }}"
     groups: '["users", "wheel"]'
-builder_aap_url: 'https://<IP_ADDRESS>/api/v2/inventories/<INVENTORY_NUMBER>/hosts/'
-builder_set_hostname: "{% raw %}{{ ansible_default_ipv4.macaddress | replace(':','') }}{% endraw %}"
-builder_aap_ks_user: 'user1'
-builder_aap_ks_password: 'pass1'
-builder_set_variables: "{% raw %}{ipaddress: {{ ansible_all_ipv4_addresses }}, macaddress: '{{ ansible_default_ipv4.macaddress }}' }{% endraw %}"

--- a/roles/builder/tasks/main.yml
+++ b/roles/builder/tasks/main.yml
@@ -128,7 +128,6 @@
     src: 'templates/kickstart.j2'
     dest: "/var/www/html/{{ builder_blueprint_name }}/kickstart.ks"
     mode: 0755
-  when: builder_aap_url is defined
 
 - name: Restore context on blueprint directory
   ansible.builtin.command: "restorecon -R /var/www/html/{{ builder_blueprint_name }}"

--- a/roles/builder/templates/kickstart.j2
+++ b/roles/builder/templates/kickstart.j2
@@ -11,6 +11,7 @@ sshkey --username={{ builder_compose_customizations['user']['name'] }} {{ builde
 
 ostreesetup --nogpg --osname=rhel --remote=edge --url=http://{{ ansible_host }}/{{ builder_blueprint_name }}/repo/ --ref={{ builder_blueprint_ref }}
 
+{% if builder_aap_url is defined %}
 %post
 # Create ansible playbook to register device to Ansible automation platform
 cat > /var/tmp/register_with_aap.yml <<EOF
@@ -54,3 +55,4 @@ EOF
 
 systemctl enable aap-auto-register-firstboot.service
 %end
+{% endif %}


### PR DESCRIPTION
Fix issue #79 

Remove aap defaults 
Update builder README to show example if the user wants the aap playbook added to the kickstart file
Conditionally create aap playbook if builder_aap_url is defined 