### PR TITLE
warn if sshkey file is undefined, add user password for kickstart, update README

### DIFF
--- a/roles/builder/README.md
+++ b/roles/builder/README.md
@@ -122,7 +122,7 @@ Required: false
 
 Password for the user that is created by the kickstart file
 
-builder_password or builder_pub_key need to be defined when using the kickstart file
+builder_password or builder_pub_key needs to be defined when using the kickstart file
 
 ### builder_pub_key
 
@@ -133,7 +133,7 @@ Path to location of ssh public key to inject into the resulting image to allow
 key-based ssh functionality without extra configuration for systems installed
 with the resulting build media.
 
-builder_password or builder_pub_key need to be defined when using the kickstart file
+builder_password or builder_pub_key needs to be defined when using the kickstart file
 
 
 Example:

--- a/roles/builder/README.md
+++ b/roles/builder/README.md
@@ -115,6 +115,15 @@ For CentOS Stream and Fedora, you will need to reference the output of the
 `composer-cli compose types` command on the osbuild server (this can also be 
 done on RHEL if preferred).
 
+### builder_password
+
+Type: string
+Required: false
+
+Password for the user that is created by the kickstart file
+
+builder_password or builder_pub_key need to be defined when using the kickstart file
+
 ### builder_pub_key
 
 Type: string
@@ -123,6 +132,9 @@ Required: false
 Path to location of ssh public key to inject into the resulting image to allow
 key-based ssh functionality without extra configuration for systems installed
 with the resulting build media.
+
+builder_password or builder_pub_key need to be defined when using the kickstart file
+
 
 Example:
 ```yaml

--- a/roles/builder/defaults/main.yml
+++ b/roles/builder/defaults/main.yml
@@ -4,7 +4,7 @@ builder_blueprint_src_path: /tmp/blueprint.toml
 builder_blueprint_distro_lower: "{{ 'rhel' if ansible_distribution == 'RedHat' else ansible_distribution | lower }}"
 builder_blueprint_ref: "{{ builder_blueprint_distro_lower }}/{{ hostvars[inventory_hostname].ansible_distribution_major_version }}/x86_64/{{ 'iot' if ansible_distribution == 'Fedora' else 'edge' }}" # noqa yaml[line-length]
 builder_compose_type: edge-commit
-builder_pub_key: "{{ lookup('file', '~/.ssh/id_rsa.pub') }}"
+builder_pub_key: "{{ lookup('file', '~/.ssh/id_rsa.pub', errors='warn') }}"
 builder_compose_pkgs:
   - "vim-enhanced"
   - "git"

--- a/roles/builder/tasks/main.yml
+++ b/roles/builder/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: Check if ssh key is defined
+  ansible.builtin.debug:
+    msg: "SSH Key nor password was defined, log in requires either an SSH key or password"
+  when: builder_pub_key | length == 0 and builder_password is not defined
+
 - name: Set fact
   when: "'installer' in builder_compose_type or 'raw' in builder_compose_type"
   ansible.builtin.set_fact:

--- a/roles/builder/templates/kickstart.j2
+++ b/roles/builder/templates/kickstart.j2
@@ -6,8 +6,11 @@ zerombr
 clearpart --all --initlabel
 autopart
 reboot
-user --name={{ builder_compose_customizations['user']['name'] }} --group=wheel,user
+user --name={{ builder_compose_customizations['user']['name'] }} {{ "--password" if builder_password is defined  }} {{ builder_password if builder_password is defined }} --group=wheel,user
+
+{% if builder_pub_key | length > 0  %}
 sshkey --username={{ builder_compose_customizations['user']['name'] }} {{ builder_pub_key }}
+{% endif %}
 
 ostreesetup --nogpg --osname=rhel --remote=edge --url=http://{{ ansible_host }}/{{ builder_blueprint_name }}/repo/ --ref={{ builder_blueprint_ref }}
 


### PR DESCRIPTION
Resolves issue #74 

warn if sshkey file is undefined
conditionally add sshkey to kickstart file if defined
conditionally add user password to kickstart file if defined
update README