### PR TITLE
Add custom kickstart

### DIFF
--- a/roles/builder/tasks/main.yml
+++ b/roles/builder/tasks/main.yml
@@ -130,9 +130,11 @@
 
 - name: Create kickstart file
   ansible.builtin.template:
-    src: 'templates/kickstart.j2'
+    force: true
+    src: "{{ builder_kickstart | default('templates/kickstart.j2') }}"
     dest: "/var/www/html/{{ builder_blueprint_name }}/kickstart.ks"
     mode: 0755
+
 
 - name: Restore context on blueprint directory
   ansible.builtin.command: "restorecon -R /var/www/html/{{ builder_blueprint_name }}"


### PR DESCRIPTION
Changes to be able to include the edge-installer kickstart file from a custom Jinja template