### PR TITLE
Skip update repo if needed

### DIFF
--- a/roles/builder/tasks/main.yml
+++ b/roles/builder/tasks/main.yml
@@ -82,7 +82,7 @@
     dest: "/tmp/{{ builder_blueprint_name }}/{{ builder_blueprint_name }}-{{ blueprint_output['current_version'] }}.{{ compose_start_out['result']['output_type'] }}" # noqa yaml[line-length]
 
 - name: Update ostree repository
-  when: builder_compose_type == 'edge-commit' or builder_compose_type == 'iot-commit'
+  when: (builder_compose_type == 'edge-commit' or builder_compose_type == 'iot-commit') and (builder_skip_repo is undefined or builder_skip_repo == false)
   block:
     - name: Untar artifact
       ansible.builtin.unarchive:

--- a/roles/builder/tasks/main.yml
+++ b/roles/builder/tasks/main.yml
@@ -82,7 +82,7 @@
     dest: "/tmp/{{ builder_blueprint_name }}/{{ builder_blueprint_name }}-{{ blueprint_output['current_version'] }}.{{ compose_start_out['result']['output_type'] }}" # noqa yaml[line-length]
 
 - name: Update ostree repository
-  when: (builder_compose_type == 'edge-commit' or builder_compose_type == 'iot-commit') and (builder_skip_repo is undefined or builder_skip_repo == false)
+  when: (builder_compose_type == 'edge-commit' or builder_compose_type == 'iot-commit') and (builder_skip_repo is undefined or not builder_skip_repo)
   block:
     - name: Untar artifact
       ansible.builtin.unarchive:


### PR DESCRIPTION
The user might want to just create the new image without updating the repo published in the Image Builder HTTP server. This is the case if you want to move the OSTree repo to another server / APP Automation Hub (in the future) or if you just want to "pre-create" the image without having to make it "public" in the repo. 

With this change, you could define the variable `builder_skip_repo=true` in order to skip this step. 