### PR TITLE
fixed issue if hostname is provided instead of ip address

### DIFF
--- a/roles/builder/vars/main.yml
+++ b/roles/builder/vars/main.yml
@@ -12,4 +12,4 @@ builder_kickstart_options:
   - network --bootproto=dhcp
   - user --name={{ builder_compose_customizations['user']['name'] }} {{ "--password" if builder_password is defined  }} {{ builder_password if builder_password is defined }} --group=wheel,user  # noqa yaml[line-length]
   - services --enabled=ostree-remount
-  - ostreesetup --nogpg --osname=rhel --remote=edge --url=http://{{ ansible_host }}/{{ builder_blueprint_name }}/repo/ --ref={{ builder_blueprint_ref }}
+  - ostreesetup --nogpg --osname=rhel --remote=edge --url=http://{{ ansible_facts["default_ipv4"]["address"] }}/{{ builder_blueprint_name }}/repo/ --ref={{ builder_blueprint_ref }}


### PR DESCRIPTION
If the host provided in an inventory is not an ip address but a name such as `home-server`. The kickstart wont resolve properly. Changing to read ip address instead of hostname