### PR TITLE
Add support for rhsm repos

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -38,7 +38,7 @@ license_file: LICENSE
 
 # A list of tags you want to associate with the collection for indexing/searching. A tag name has the same character
 # requirements as 'namespace' and 'name'
-tags: []
+tags: ['infrastructure']
 
 # Collections that this collection requires to be installed for it to be usable. The key of the dict is the
 # collection label 'namespace.name'. The value is a version range

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: ">=2.12"
+requires_ansible: ">=2.14"

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: ">=2.14"
+requires_ansible: ">=2.12.0"

--- a/playbooks/microshift-rhsm.yml
+++ b/playbooks/microshift-rhsm.yml
@@ -1,9 +1,9 @@
 ---
 - name: Build Microshift Image
-  hosts: rhel8builder
+  hosts: all
   gather_facts: true
   vars:
-    builder_blueprint_name: microshift
+    builder_blueprint_name: microshift-rhsm
     builder_blueprint_src_path: "/tmp/microshift.toml"
     compose_type: edge-commit
     pubkey_file: "{{ lookup('file','~/.ssh/id_rsa.pub') }}"
@@ -27,6 +27,10 @@
     - name: Run the setup server role
       ansible.builtin.import_role:
         name: infra.osbuild.setup_server
+    - name: Get rhsm repos properties
+      infra.osbuild.rhsm_repo_info:
+        name: "{{ builder_rhsm_repos }}"
+      register: builder_rhsm_repos_info
     - name: Run the builder role
       ansible.builtin.import_role:
         name: infra.osbuild.builder

--- a/playbooks/microshift-rhsm.yml
+++ b/playbooks/microshift-rhsm.yml
@@ -8,8 +8,8 @@
     compose_type: edge-commit
     pubkey_file: "{{ lookup('file','~/.ssh/id_rsa.pub') }}"
     builder_rhsm_repos:
-      - name: "rhocp-4.12-for-rhel-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}-rpms"
-      - name: "fast-datapath-for-rhel-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}-rpms"
+      - "rhocp-4.12-for-rhel-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}-rpms"
+      - "fast-datapath-for-rhel-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}-rpms"
     builder_compose_pkgs:
       - vim-enhanced
       - git
@@ -29,7 +29,7 @@
         name: infra.osbuild.setup_server
     - name: Get rhsm repos properties
       infra.osbuild.rhsm_repo_info:
-        name: "{{ builder_rhsm_repos }}"
+        repos: "{{ builder_rhsm_repos }}"
       register: builder_rhsm_repos_info
     - name: Run the builder role
       ansible.builtin.import_role:

--- a/playbooks/microshift-rhsm.yml
+++ b/playbooks/microshift-rhsm.yml
@@ -1,0 +1,32 @@
+---
+- name: Build Microshift Image
+  hosts: rhel8builder
+  gather_facts: true
+  vars:
+    builder_blueprint_name: microshift
+    builder_blueprint_src_path: "/tmp/microshift.toml"
+    compose_type: edge-commit
+    pubkey_file: "{{ lookup('file','~/.ssh/id_rsa.pub') }}"
+    builder_rhsm_repos:
+      - name: "rhocp-4.12-for-rhel-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}-rpms"
+      - name: "fast-datapath-for-rhel-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}-rpms"
+    builder_compose_pkgs:
+      - vim-enhanced
+      - git
+      - nano
+      - microshift
+      - NetworkManager-wifi
+    builder_compose_customizations:
+      user:
+        name: "edge"
+        description: "test user"
+        password: "openshift"
+        key: "{{ pubkey_file }}"
+        groups: '["users", "wheel"]'
+  tasks:
+    - name: Run the setup server role
+      ansible.builtin.import_role:
+        name: infra.osbuild.setup_server
+    - name: Run the builder role
+      ansible.builtin.import_role:
+        name: infra.osbuild.builder

--- a/playbooks/testbuild.yml
+++ b/playbooks/testbuild.yml
@@ -54,7 +54,7 @@
         - name: Create blueprint directory
           ansible.builtin.file:
             path: "/var/www/html/{{ blueprint_name }}"
-            mode: 0755
+            mode: '0755'
             state: directory
         - name: Initialize repository
           ansible.builtin.command:
@@ -80,7 +80,7 @@
     - name: Create tmp directory for blueprint
       ansible.builtin.file:
         path: "/tmp/{{ blueprint_name }}"
-        mode: 0755
+        mode: '0755'
         state: directory
 
     - name: Export the compose artifact

--- a/plugins/module_utils/weldr.py
+++ b/plugins/module_utils/weldr.py
@@ -3,7 +3,7 @@
 # (c) 2022, Adam Miller (admiller@redhat.com)
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from ansible.module_utils._text import to_bytes, to_native, to_text
+from ansible.module_utils._text import to_native, to_text
 from ansible_collections.infra.osbuild.plugins.module_utils.weldrapiv1 import WeldrV1
 import ansible.module_utils.six.moves.urllib.error as urllib_error
 from ansible.module_utils.urls import Request

--- a/plugins/module_utils/weldrapiv1.py
+++ b/plugins/module_utils/weldrapiv1.py
@@ -3,7 +3,7 @@
 # (c) 2022, Adam Miller (admiller@redhat.com)
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from ansible.module_utils._text import to_bytes, to_native, to_text
+from ansible.module_utils._text import to_bytes, to_native
 import ansible.module_utils.six.moves.urllib.error as urllib_error
 from ansible.module_utils.six.moves.urllib.parse import quote
 import json

--- a/plugins/module_utils/weldrapiv1.py
+++ b/plugins/module_utils/weldrapiv1.py
@@ -90,7 +90,7 @@ class WeldrV1(object):
         results = json.load(
             self.weldr.request.open(
                 "POST",
-                "http://localhost/api/v0/projects/source/new",
+                "http://localhost/api/v1/projects/source/new",
                 data=source,
                 headers={"Content-Type": "application/json"},
             )
@@ -107,7 +107,7 @@ class WeldrV1(object):
         results = json.load(
             self.weldr.request.open(
                 "GET",
-                "http://localhost/api/v0/projects/source/info/%s" % quote(repo_name),
+                "http://localhost/api/v1/projects/source/info/%s" % quote(repo_name),
                 headers={"Content-Type": "application/json"},
             )
         )
@@ -123,7 +123,7 @@ class WeldrV1(object):
         results = json.load(
             self.weldr.request.open(
                 "DELETE",
-                "http://localhost/api/v0/projects/source/delete/%s" % quote(repo_name),
+                "http://localhost/api/v1/projects/source/delete/%s" % quote(repo_name),
                 headers={"Content-Type": "application/json"},
             )
         )

--- a/plugins/modules/create_blueprint.py
+++ b/plugins/modules/create_blueprint.py
@@ -109,7 +109,6 @@ EXAMPLES = """
 """
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native, to_text
 from ansible_collections.infra.osbuild.plugins.module_utils.weldr import Weldr
 
 

--- a/plugins/modules/export_compose.py
+++ b/plugins/modules/export_compose.py
@@ -48,11 +48,7 @@ EXAMPLES = """
     dest: "/usr/share/composes/mycompose_artifact.tar"
 """
 
-import re
-import time
-
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native, to_text
 from ansible_collections.infra.osbuild.plugins.module_utils.weldr import Weldr
 
 

--- a/plugins/modules/inject_ks.py
+++ b/plugins/modules/inject_ks.py
@@ -57,7 +57,6 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.locale import get_best_parsable_locale
 
 import os
-import subprocess
 
 
 def main():

--- a/plugins/modules/list_blueprints.py
+++ b/plugins/modules/list_blueprints.py
@@ -32,11 +32,7 @@ EXAMPLES = """
 - debug: var=list_blueprints
 """
 
-import os
-import traceback
-
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native, to_text
 from ansible_collections.infra.osbuild.plugins.module_utils.weldr import Weldr
 
 

--- a/plugins/modules/push_blueprint.py
+++ b/plugins/modules/push_blueprint.py
@@ -45,12 +45,8 @@ EXAMPLES = """
     src: /tmp/blueprint.toml
 """
 
-
-import os
-import traceback
-
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native, to_text
+from ansible.module_utils._text import to_text
 from ansible_collections.infra.osbuild.plugins.module_utils.weldr import Weldr
 
 

--- a/plugins/modules/rhsm_repo_info.py
+++ b/plugins/modules/rhsm_repo_info.py
@@ -64,7 +64,7 @@ def main() -> None:
                     "type": "yum-baseurl",
                     "check_ssl": True if items['sslverify'] == '1' else False,
                     "check_gpg": True if items['gpgcheck'] == '1' else False,
-                    "gpgkey_urls": items['gpgkey'],
+                    "gpgkey_paths": items['gpgkey'],
                     "state": 'present',
                 })
                 has_changed = True

--- a/plugins/modules/rhsm_repo_info.py
+++ b/plugins/modules/rhsm_repo_info.py
@@ -1,0 +1,60 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: Red Hat Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    "metadata_version": "1.1",
+    "status": ["preview"],
+    "supported_by": "community",
+}
+
+DOCUMENTATION = """
+---
+module: rhsm_repo_info
+short_description: Gather information about rhsm repositories
+description:
+    - Gather information about rhsm repositories
+author:
+    - Adam Miller (@maxamillion)
+    - Matthew Sandoval (@matoval)
+options:
+"""
+
+EXAMPLES = """
+- name: Add source for custom packages
+  infra.osbuild.rhsm_repo_info:
+    name:
+     - rhocp-ironic-4.12-for-rhel-8-x86_64-rpms
+  register: rhsm_repo_info_out
+
+- name: Debug rhsm_repo_info_out
+  ansible.builtin.debug:
+    var: rhsm_repo_info_out
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native, to_text, to_bytes
+from ansible_collections.infra.osbuild.plugins.module_utils.weldr import Weldr
+
+import shutil
+import configparser
+
+def main() -> None:
+    module = AnsibleModule(
+        argument_spec=dict(
+            name=dict(type="list", required=True),
+        ),
+    )
+
+
+    results: dict = {}
+    has_changed: bool = False
+
+
+

--- a/plugins/modules/start_compose.py
+++ b/plugins/modules/start_compose.py
@@ -120,7 +120,6 @@ import json
 import socket
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native, to_text
 from ansible_collections.infra.osbuild.plugins.module_utils.weldr import Weldr
 
 

--- a/plugins/modules/wait_compose.py
+++ b/plugins/modules/wait_compose.py
@@ -51,11 +51,9 @@ EXAMPLES = """
     timeout: 3600
 """
 
-import re
 import time
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native, to_text
 from ansible_collections.infra.osbuild.plugins.module_utils.weldr import Weldr
 
 

--- a/roles/builder/README.md
+++ b/roles/builder/README.md
@@ -48,26 +48,18 @@ builder_custom_repos:
 
 ### builder_rhsm_repos
 
-Type: complex
+Type: list
 Required: false
 
-Custom list of RPM repositories to make available to the 
+List of RHSM repositories to make available to the 
 [osbuild](https://www.osbuild.org/) [compose builds](https://www.osbuild.org/guides/user-guide/user-guide.html).
-
-Each list entry is a [YAML dictionary](https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html)
-type and has the following attributes:
-
-| Variable Name | Type                              | Required  | Default Value |
-|---------------|-----------------------------------|-----------|---------------|
-| name          | string                            | **Yes**   | n/a           |
-| state         | string ("present" or "absent" )   | No        | "present"     | 
 
 Example:
 
 ```yaml
 builder_rhsm_repos:
-  - name: "rhocp-4.12-for-rhel-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}-rpms"
-  - name: "fast-datapath-for-rhel-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}-rpms"
+  - "rhocp-4.12-for-rhel-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}-rpms"
+  - "fast-datapath-for-rhel-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}-rpms"
 ```
 
 #### NOTES:

--- a/roles/builder/README.md
+++ b/roles/builder/README.md
@@ -46,6 +46,30 @@ builder_custom_repos:
     base_url: "https://repo.example.com/company_repo/x86_64/"
 ```
 
+### builder_rhsm_repos
+
+Type: complex
+Required: false
+
+Custom list of RPM repositories to make available to the 
+[osbuild](https://www.osbuild.org/) [compose builds](https://www.osbuild.org/guides/user-guide/user-guide.html).
+
+Each list entry is a [YAML dictionary](https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html)
+type and has the following attributes:
+
+| Variable Name | Type                              | Required  | Default Value |
+|---------------|-----------------------------------|-----------|---------------|
+| name          | string                            | **Yes**   | n/a           |
+| state         | string ("present" or "absent" )   | No        | "present"     | 
+
+Example:
+
+```yaml
+builder_rhsm_repos:
+  - name: "rhocp-4.12-for-rhel-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}-rpms"
+  - name: "fast-datapath-for-rhel-{{ ansible_distribution_major_version }}-{{ ansible_architecture }}-rpms"
+```
+
 #### NOTES:
 
 osbuild performs builds in [multiple stages](https://www.osbuild.org/guides/developer-guide/osbuild.html?highlight=stage#osbuild)

--- a/roles/builder/tasks/disable_custom_repos.yml
+++ b/roles/builder/tasks/disable_custom_repos.yml
@@ -22,3 +22,21 @@
       loop: "{{ builder_custom_repos }}"
       loop_control:
         loop_var: __builder_repo
+
+- name: Remove source for additional RHSM packages
+  when:
+    - builder_rhsm_repos is defined
+  block:
+    - name: Loop through the repos to debug them
+      ansible.builtin.debug:
+        var: __builder_rhsm_repo
+      loop: "{{ builder_rhsm_repos }}"
+      loop_control:
+        loop_var: __builder_rhsm_repo
+    - name: Loop through the repos and configure them
+      community.general.rhsm_repository:
+        name: "{{ __builder_rhsm_repo['name'] }}"
+        state: "absent"
+      loop: "{{ builder_rhsm_repos }}"
+      loop_control:
+        loop_var: __builder_rhsm_repo

--- a/roles/builder/tasks/enable_custom_repos.yml
+++ b/roles/builder/tasks/enable_custom_repos.yml
@@ -24,18 +24,24 @@
 
 - name: Add RHSM repos for additional Red Hat packages
   when:
-    - builder_rhsm_repos is defined
+    - builder_rhsm_repos_info is defined
   block:
     - name: Loop through the RHSM repos to debug them
       ansible.builtin.debug:
         var: __builder_rhsm_repo
-      loop: "{{ builder_rhsm_repos }}"
+      loop: "{{ builder_rhsm_repos_info['rhsm_info'] }}"
       loop_control:
         loop_var: __builder_rhsm_repo
     - name: Loop through the repos and configure them
-      community.general.rhsm_repository:
-        name: "{{ __builder_rhsm_repo['name'] }}"
+      infra.osbuild.repository:
+        repo_name: "{{ __builder_rhsm_repo['name'] }}"
+        base_url: "{{ __builder_rhsm_repo['base_url'] }}"
+        type: "{{ __builder_rhsm_repo['type'] | default('yum-baseurl') }}"
+        check_ssl: "{{ __builder_rhsm_repo['check_ssl'] | default(true) }}"
+        check_gpg: "{{ __builder_rhsm_repo['check_gpg'] | default(true) }}"
+        gpgkey_urls: "{{ __builder_rhsm_repo['gpgkey_urls'] | default(omit) }}"
+        rhsm: true
         state: "{{ __builder_rhsm_repo['state'] | default('present') }}"
-      loop: "{{ builder_rhsm_repos }}"
+      loop: "{{ builder_rhsm_repos_info['rhsm_info'] }}"
       loop_control:
         loop_var: __builder_rhsm_repo

--- a/roles/builder/tasks/enable_custom_repos.yml
+++ b/roles/builder/tasks/enable_custom_repos.yml
@@ -21,3 +21,21 @@
       loop: "{{ builder_custom_repos }}"
       loop_control:
         loop_var: __builder_repo
+
+- name: Add RHSM repos for additional Red Hat packages
+  when:
+    - builder_rhsm_repos is defined
+  block:
+    - name: Loop through the RHSM repos to debug them
+      ansible.builtin.debug:
+        var: __builder_rhsm_repo
+      loop: "{{ builder_rhsm_repos }}"
+      loop_control:
+        loop_var: __builder_rhsm_repo
+    - name: Loop through the repos and configure them
+      community.general.rhsm_repository:
+        name: "{{ __builder_rhsm_repo['name'] }}"
+        state: "{{ __builder_rhsm_repo['state'] | default('present') }}"
+      loop: "{{ builder_rhsm_repos }}"
+      loop_control:
+        loop_var: __builder_rhsm_repo

--- a/roles/builder/tasks/enable_custom_repos.yml
+++ b/roles/builder/tasks/enable_custom_repos.yml
@@ -39,7 +39,7 @@
         type: "{{ __builder_rhsm_repo['type'] | default('yum-baseurl') }}"
         check_ssl: "{{ __builder_rhsm_repo['check_ssl'] | default(true) }}"
         check_gpg: "{{ __builder_rhsm_repo['check_gpg'] | default(true) }}"
-        gpgkey_urls: "{{ __builder_rhsm_repo['gpgkey_urls'] | default(omit) }}"
+        gpgkey_paths: "{{ __builder_rhsm_repo['gpgkey_paths'] | default(omit) }}"
         rhsm: true
         state: "{{ __builder_rhsm_repo['state'] | default('present') }}"
       loop: "{{ builder_rhsm_repos_info['rhsm_info'] }}"

--- a/roles/builder/tasks/main.yml
+++ b/roles/builder/tasks/main.yml
@@ -51,7 +51,7 @@
     - name: Create blueprint directory
       ansible.builtin.file:
         path: "/var/www/html/{{ builder_blueprint_name }}"
-        mode: 0755
+        mode: '0755'
         state: directory
     - name: Initialize repository
       ansible.builtin.command:
@@ -73,7 +73,7 @@
 - name: Create tmp directory for blueprint
   ansible.builtin.file:
     path: "/tmp/{{ builder_blueprint_name }}"
-    mode: 0755
+    mode: '0755'
     state: directory
 
 - name: Export the compose artifact
@@ -117,14 +117,14 @@
     - name: Create images directory
       ansible.builtin.file:
         path: "/var/www/html/{{ builder_blueprint_name }}/images"
-        mode: 0755
+        mode: '0755'
         state: directory
     - name: Copy image to web dir
       ansible.builtin.copy:
         src: "/tmp/{{ builder_blueprint_name }}/{{ builder_blueprint_name }}-{{ blueprint_output['current_version'] }}.{{ compose_start_out['result']['output_type'] }}" # noqa yaml[line-length]
         dest: "/var/www/html/{{ builder_blueprint_name }}/images/{{ builder_blueprint_name }}_{{ builder_compose_type }}.{{ compose_start_out['result']['output_type'] }}"
         remote_src: true
-        mode: 0644
+        mode: '0644'
         owner: apache
         group: apache
 
@@ -132,7 +132,7 @@
   ansible.builtin.template:
     src: "{{ builder_kickstart | default('templates/kickstart.j2') }}"
     dest: "/var/www/html/{{ builder_blueprint_name }}/kickstart.ks"
-    mode: 0755
+    mode: '0755'
 
 - name: Restore context on blueprint directory
   ansible.builtin.command: "restorecon -R /var/www/html/{{ builder_blueprint_name }}"
@@ -188,7 +188,7 @@
     - name: Create tmp directory for blueprint
       ansible.builtin.file:
         path: "/tmp/{{ builder_blueprint_name }}"
-        mode: 0755
+        mode: '0755'
         state: directory
 
     - name: Export the compose artifact
@@ -199,7 +199,7 @@
     - name: Create images directory
       ansible.builtin.file:
         path: "/var/www/html/{{ builder_blueprint_name }}/images"
-        mode: 0755
+        mode: '0755'
         state: directory
 
     - name: Inject kickstart into iso
@@ -213,6 +213,6 @@
         src: "/tmp/{{ builder_blueprint_name }}/{{ builder_blueprint_name }}-{{ blueprint_output['current_version'] }}.{{ compose_start_out['result']['output_type'] }}" # noqa yaml[line-length]
         dest: "/var/www/html/{{ builder_blueprint_name }}/images/{{ builder_blueprint_name }}_{{ _builder_compose_type }}.{{ compose_start_out['result']['output_type'] }}"
         remote_src: true
-        mode: 0644
+        mode: '0644'
         owner: apache
         group: apache

--- a/roles/builder/tests/test.yml
+++ b/roles/builder/tests/test.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhost
+- name: Test
+  hosts: localhost
   remote_user: root
   roles:
     - builder

--- a/tests/integration/targets/role_setup_server/tasks/main.yml
+++ b/tests/integration/targets/role_setup_server/tasks/main.yml
@@ -18,13 +18,13 @@
     - name: Setup osbuild overrides directory
       ansible.builtin.file:
         path: /etc/osbuild-composer/repositories
-        mode: 0755
+        mode: '0755'
         state: directory
 
     - name: Setup testing osbuild rhel9 fake repos
       ansible.builtin.copy:
         src: "files/{{ item }}.json"
-        mode: 0644
+        mode: '0644'
         dest: "/etc/osbuild-composer/repositories/{{ item }}.json"
       loop:
         - centos-9


### PR DESCRIPTION
Add support for rhsm repos by adding a module to get rhsm repo info and update the repository module to handle rhsm repos.

Side effect reslove issue #85 we are now setting rhsm property in sources correctly.

Resolved issue #98 while fixing sanity and lint failures.