### PR TITLE
Fix kickstart post omit issue

### DIFF
--- a/roles/builder/README.md
+++ b/roles/builder/README.md
@@ -229,12 +229,13 @@ builder_kickstart_options:
 Type: list
 Required: false
 
-List of kickstart post options to add to the kickstart file
+List of kickstart post options to add to the kickstart file. Use default(None) when conditionally setting a variable in the builder_kickstart_post list.
 
 Example:
 ```yaml
 builder_kickstart_post: 
   - "{{ lookup('ansible.builtin.template', '../templates/auto_register_aap.j2') }}"
+  - "{{ microshift_image_ovn_options_template | default(None) }}"
 ```
 
 ## Kickstart AAP Variables

--- a/roles/builder/templates/kickstart.j2
+++ b/roles/builder/templates/kickstart.j2
@@ -10,8 +10,10 @@ sshkey --username={{ builder_compose_customizations['user']['name'] }} {{ builde
 
 {% if builder_kickstart_post is defined and builder_kickstart_post | length > 0 %}
 {% for post in builder_kickstart_post %}
+{% if post != "" %}
 %post
 {{ post }}
 %end
+{% endif %}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
Fix kickstart template to handle omit, add to readme to document how to set omit properly for the builder_kickstart_post variable.

Resolves issue #96 