### PR TITLE
Fix internal key warning

### DIFF
--- a/plugins/modules/push_blueprint.py
+++ b/plugins/modules/push_blueprint.py
@@ -82,7 +82,7 @@ def main():
         data = weldr.toml.loads(module.params["blueprint"])
 
     results = weldr.api.post_blueprint_new(weldr.toml.dumps(data))
-    module.exit_json(results=results, msg="Blueprint pushed to osbuild composer")
+    module.exit_json(result=results, msg="Blueprint pushed to osbuild composer")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The "results" key is a reserved module return value[1] and using it results in the following:

[WARNING]: Found internal 'results' key in module return, renamed to 'ansible_module_results'.

Renamed return key to "result" which matches many of the existing modules in the infra.osbuild collection.

[1] https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#results