### PR TITLE
Add builder_ostree_url variable to build installer with existing commit

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -158,10 +158,10 @@ stages:
         parameters:
           testFormat: devel/{0}
           targets:
-            - name: RHEL 9.0 edge-installer
-              test: rhel/9.0
-            - name: RHEL 8.6 edge-installer
-              test: rhel/8.6
+            - name: RHEL 9.1 edge-installer
+              test: rhel/9.1
+            - name: RHEL 8.7 edge-installer
+              test: rhel/8.7
           groups:
             - 6
 
@@ -193,10 +193,10 @@ stages:
         parameters:
           testFormat: devel/{0}
           targets:
-            - name: RHEL 9.0 image-installer
-              test: rhel/9.0
-            - name: RHEL 8.6 image-installer
-              test: rhel/8.6
+            - name: RHEL 9.1 image-installer
+              test: rhel/9.1
+            - name: RHEL 8.7 image-installer
+              test: rhel/8.7
           groups:
             - 9
       - template: templates/matrix.yml
@@ -219,8 +219,8 @@ stages:
         parameters:
           testFormat: devel/{0}
           targets:
-            - name: Fedora 36 iot-installer
-              test: fedora/36
+            - name: Fedora 37 iot-installer
+              test: fedora/37
           groups:
             - 12
 

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -154,16 +154,18 @@ stages:
               test: rhel/8.7
           groups:
             - 5
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: devel/{0}
-          targets:
-            - name: RHEL 9.1 edge-installer
-              test: rhel/9.1
-            - name: RHEL 8.7 edge-installer
-              test: rhel/8.7
-          groups:
-            - 6
+
+      # Fixme
+      # - template: templates/matrix.yml
+      #   parameters:
+      #     testFormat: devel/{0}
+      #     targets:
+      #       - name: RHEL 9.1 edge-installer
+      #         test: rhel/9.1
+      #       - name: RHEL 8.7 edge-installer
+      #         test: rhel/8.7
+      #     groups:
+      #       - 6
 
       # Fixme
       # - template: templates/matrix.yml
@@ -189,16 +191,18 @@ stages:
       #     groups:
       #       - 8
 
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: devel/{0}
-          targets:
-            - name: RHEL 9.1 image-installer
-              test: rhel/9.1
-            - name: RHEL 8.7 image-installer
-              test: rhel/8.7
-          groups:
-            - 9
+      # Fixme
+      # - template: templates/matrix.yml
+      #   parameters:
+      #     testFormat: devel/{0}
+      #     targets:
+      #       - name: RHEL 9.1 image-installer
+      #         test: rhel/9.1
+      #       - name: RHEL 8.7 image-installer
+      #         test: rhel/8.7
+      #     groups:
+      #       - 9
+
       - template: templates/matrix.yml
         parameters:
           testFormat: devel/{0}
@@ -215,14 +219,16 @@ stages:
               test: fedora/37
           groups:
             - 11
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: devel/{0}
-          targets:
-            - name: Fedora 37 iot-installer
-              test: fedora/37
-          groups:
-            - 12
+
+      # Fixme
+      # - template: templates/matrix.yml
+      #   parameters:
+      #     testFormat: devel/{0}
+      #     targets:
+      #       - name: Fedora 37 iot-installer
+      #         test: fedora/37
+      #     groups:
+      #       - 12
 
       # Fixme
       # - template: templates/matrix.yml
@@ -345,16 +351,18 @@ stages:
               test: rhel/8.6
           groups:
             - 5
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.14/{0}
-          targets:
-            - name: RHEL 9.0 edge-installer
-              test: rhel/9.0
-            - name: RHEL 8.6 edge-installer
-              test: rhel/8.6
-          groups:
-            - 6
+
+      # Fixme
+      # - template: templates/matrix.yml
+      #   parameters:
+      #     testFormat: 2.14/{0}
+      #     targets:
+      #       - name: RHEL 9.0 edge-installer
+      #         test: rhel/9.0
+      #       - name: RHEL 8.6 edge-installer
+      #         test: rhel/8.6
+      #     groups:
+      #       - 6
 
       # Fixme
       # - template: templates/matrix.yml
@@ -380,16 +388,18 @@ stages:
       #     groups:
       #       - 8
 
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.14/{0}
-          targets:
-            - name: RHEL 9.0 image-installer
-              test: rhel/9.0
-            - name: RHEL 8.6 image-installer
-              test: rhel/8.6
-          groups:
-            - 9
+      # Fixme
+      # - template: templates/matrix.yml
+      #   parameters:
+      #     testFormat: 2.14/{0}
+      #     targets:
+      #       - name: RHEL 9.0 image-installer
+      #         test: rhel/9.0
+      #       - name: RHEL 8.6 image-installer
+      #         test: rhel/8.6
+      #     groups:
+      #       - 9
+
       - template: templates/matrix.yml
         parameters:
           testFormat: 2.14/{0}
@@ -406,14 +416,16 @@ stages:
               test: fedora/36
           groups:
             - 11
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.14/{0}
-          targets:
-            - name: Fedora 36 iot-installer
-              test: fedora/36
-          groups:
-            - 12
+
+      # Fixme
+      # - template: templates/matrix.yml
+      #   parameters:
+      #     testFormat: 2.14/{0}
+      #     targets:
+      #       - name: Fedora 36 iot-installer
+      #         test: fedora/36
+      #     groups:
+      #       - 12
 
       # Fixme
       # - template: templates/matrix.yml
@@ -528,16 +540,18 @@ stages:
               test: rhel/8.5
           groups:
             - 5
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.13/{0}
-          targets:
-            - name: RHEL 9.0 edge-installer
-              test: rhel/9.0
-            - name: RHEL 8.5 edge-installer
-              test: rhel/8.5
-          groups:
-            - 6
+      
+      # Fixme
+      # - template: templates/matrix.yml
+      #   parameters:
+      #     testFormat: 2.13/{0}
+      #     targets:
+      #       - name: RHEL 9.0 edge-installer
+      #         test: rhel/9.0
+      #       - name: RHEL 8.5 edge-installer
+      #         test: rhel/8.5
+      #     groups:
+      #       - 6
 
       # Fixme
       # - template: templates/matrix.yml
@@ -559,16 +573,18 @@ stages:
       #     groups:
       #       - 8
 
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.13/{0}
-          targets:
-            - name: RHEL 9.0 image-installer
-              test: rhel/9.0
-            - name: RHEL 8.5 image-installer
-              test: rhel/8.5
-          groups:
-            - 9
+      # Fixme
+      # - template: templates/matrix.yml
+      #   parameters:
+      #     testFormat: 2.13/{0}
+      #     targets:
+      #       - name: RHEL 9.0 image-installer
+      #         test: rhel/9.0
+      #       - name: RHEL 8.5 image-installer
+      #         test: rhel/8.5
+      #     groups:
+      #       - 9
+
       - template: templates/matrix.yml
         parameters:
           testFormat: 2.13/{0}
@@ -665,22 +681,26 @@ stages:
               test: rhel/8.4
           groups:
             - 5
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.12/{0}
-          targets:
-            - name: RHEL 8.4 edge-installer
-              test: rhel/8.4
-          groups:
-            - 6
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.12/{0}
-          targets:
-            - name: RHEL 8.4 image-installer
-              test: rhel/8.4
-          groups:
-            - 9
+      # Fixme
+      # - template: templates/matrix.yml
+      #   parameters:
+      #     testFormat: 2.12/{0}
+      #     targets:
+      #       - name: RHEL 8.4 edge-installer
+      #         test: rhel/8.4
+      #     groups:
+      #       - 6
+
+      # Fixme
+      # - template: templates/matrix.yml
+      #   parameters:
+      #     testFormat: 2.12/{0}
+      #     targets:
+      #       - name: RHEL 8.4 image-installer
+      #         test: rhel/8.4
+      #     groups:
+      #       - 9
+      
       - template: templates/matrix.yml
         parameters:
           testFormat: 2.12/{0}

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -540,7 +540,7 @@ stages:
               test: rhel/8.5
           groups:
             - 5
-      
+
       # Fixme
       # - template: templates/matrix.yml
       #   parameters:
@@ -700,7 +700,7 @@ stages:
       #         test: rhel/8.4
       #     groups:
       #       - 9
-      
+
       - template: templates/matrix.yml
         parameters:
           testFormat: 2.12/{0}

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -154,18 +154,16 @@ stages:
               test: rhel/8.7
           groups:
             - 5
-
-      # Fixme
-      # - template: templates/matrix.yml
-      #   parameters:
-      #     testFormat: devel/{0}
-      #     targets:
-      #       - name: RHEL 9.0 edge-installer
-      #         test: rhel/9.0
-      #       - name: RHEL 8.6 edge-installer
-      #         test: rhel/8.6
-      #     groups:
-      #       - 6
+      - template: templates/matrix.yml
+        parameters:
+          testFormat: devel/{0}
+          targets:
+            - name: RHEL 9.0 edge-installer
+              test: rhel/9.0
+            - name: RHEL 8.6 edge-installer
+              test: rhel/8.6
+          groups:
+            - 6
 
       # Fixme
       # - template: templates/matrix.yml
@@ -191,17 +189,16 @@ stages:
       #     groups:
       #       - 8
 
-      # Fixme
-      # - template: templates/matrix.yml
-      #   parameters:
-      #     testFormat: devel/{0}
-      #     targets:
-      #       - name: RHEL 9.0 image-installer
-      #         test: rhel/9.0
-      #       - name: RHEL 8.6 image-installer
-      #         test: rhel/8.6
-      #     groups:
-      #       - 9
+      - template: templates/matrix.yml
+        parameters:
+          testFormat: devel/{0}
+          targets:
+            - name: RHEL 9.0 image-installer
+              test: rhel/9.0
+            - name: RHEL 8.6 image-installer
+              test: rhel/8.6
+          groups:
+            - 9
       - template: templates/matrix.yml
         parameters:
           testFormat: devel/{0}
@@ -218,15 +215,14 @@ stages:
               test: fedora/37
           groups:
             - 11
-      # Fixme
-      # - template: templates/matrix.yml
-      #   parameters:
-      #     testFormat: devel/{0}
-      #     targets:
-      #       - name: Fedora 36 iot-installer
-      #         test: fedora/36
-      #     groups:
-      #       - 12
+      - template: templates/matrix.yml
+        parameters:
+          testFormat: devel/{0}
+          targets:
+            - name: Fedora 36 iot-installer
+              test: fedora/36
+          groups:
+            - 12
 
       # Fixme
       # - template: templates/matrix.yml
@@ -349,18 +345,16 @@ stages:
               test: rhel/8.6
           groups:
             - 5
-
-      # Fixme
-      # - template: templates/matrix.yml
-      #   parameters:
-      #     testFormat: 2.14/{0}
-      #     targets:
-      #       - name: RHEL 9.0 edge-installer
-      #         test: rhel/9.0
-      #       - name: RHEL 8.6 edge-installer
-      #         test: rhel/8.6
-      #     groups:
-      #       - 6
+      - template: templates/matrix.yml
+        parameters:
+          testFormat: 2.14/{0}
+          targets:
+            - name: RHEL 9.0 edge-installer
+              test: rhel/9.0
+            - name: RHEL 8.6 edge-installer
+              test: rhel/8.6
+          groups:
+            - 6
 
       # Fixme
       # - template: templates/matrix.yml
@@ -386,17 +380,16 @@ stages:
       #     groups:
       #       - 8
 
-      # Fixme
-      # - template: templates/matrix.yml
-      #   parameters:
-      #     testFormat: 2.14/{0}
-      #     targets:
-      #       - name: RHEL 9.0 image-installer
-      #         test: rhel/9.0
-      #       - name: RHEL 8.6 image-installer
-      #         test: rhel/8.6
-      #     groups:
-      #       - 9
+      - template: templates/matrix.yml
+        parameters:
+          testFormat: 2.14/{0}
+          targets:
+            - name: RHEL 9.0 image-installer
+              test: rhel/9.0
+            - name: RHEL 8.6 image-installer
+              test: rhel/8.6
+          groups:
+            - 9
       - template: templates/matrix.yml
         parameters:
           testFormat: 2.14/{0}
@@ -413,16 +406,14 @@ stages:
               test: fedora/36
           groups:
             - 11
-
-      # Fixme
-      # - template: templates/matrix.yml
-      #   parameters:
-      #     testFormat: 2.14/{0}
-      #     targets:
-      #       - name: Fedora 36 iot-installer
-      #         test: fedora/36
-      #     groups:
-      #       - 12
+      - template: templates/matrix.yml
+        parameters:
+          testFormat: 2.14/{0}
+          targets:
+            - name: Fedora 36 iot-installer
+              test: fedora/36
+          groups:
+            - 12
 
       # Fixme
       # - template: templates/matrix.yml
@@ -537,18 +528,16 @@ stages:
               test: rhel/8.5
           groups:
             - 5
-
-      # Fixme
-      # - template: templates/matrix.yml
-      #   parameters:
-      #     testFormat: 2.13/{0}
-      #     targets:
-      #       - name: RHEL 9.0 edge-installer
-      #         test: rhel/9.0
-      #       - name: RHEL 8.5 edge-installer
-      #         test: rhel/8.5
-      #     groups:
-      #       - 6
+      - template: templates/matrix.yml
+        parameters:
+          testFormat: 2.13/{0}
+          targets:
+            - name: RHEL 9.0 edge-installer
+              test: rhel/9.0
+            - name: RHEL 8.5 edge-installer
+              test: rhel/8.5
+          groups:
+            - 6
 
       # Fixme
       # - template: templates/matrix.yml
@@ -570,17 +559,16 @@ stages:
       #     groups:
       #       - 8
 
-      # Fixme
-      # - template: templates/matrix.yml
-      #   parameters:
-      #     testFormat: 2.13/{0}
-      #     targets:
-      #       - name: RHEL 9.0 image-installer
-      #         test: rhel/9.0
-      #       - name: RHEL 8.5 image-installer
-      #         test: rhel/8.5
-      #     groups:
-      #       - 9
+      - template: templates/matrix.yml
+        parameters:
+          testFormat: 2.13/{0}
+          targets:
+            - name: RHEL 9.0 image-installer
+              test: rhel/9.0
+            - name: RHEL 8.5 image-installer
+              test: rhel/8.5
+          groups:
+            - 9
       - template: templates/matrix.yml
         parameters:
           testFormat: 2.13/{0}
@@ -677,26 +665,22 @@ stages:
               test: rhel/8.4
           groups:
             - 5
-
-      # Fixme
-      # - template: templates/matrix.yml
-      #   parameters:
-      #     testFormat: 2.12/{0}
-      #     targets:
-      #       - name: RHEL 8.4 edge-installer
-      #         test: rhel/8.4
-      #     groups:
-      #       - 6
-
-      # Fixme
-      # - template: templates/matrix.yml
-      #   parameters:
-      #     testFormat: 2.12/{0}
-      #     targets:
-      #       - name: RHEL 8.4 image-installer
-      #         test: rhel/8.4
-      #     groups:
-      #       - 9
+      - template: templates/matrix.yml
+        parameters:
+          testFormat: 2.12/{0}
+          targets:
+            - name: RHEL 8.4 edge-installer
+              test: rhel/8.4
+          groups:
+            - 6
+      - template: templates/matrix.yml
+        parameters:
+          testFormat: 2.12/{0}
+          targets:
+            - name: RHEL 8.4 image-installer
+              test: rhel/8.4
+          groups:
+            - 9
       - template: templates/matrix.yml
         parameters:
           testFormat: 2.12/{0}

--- a/roles/builder/README.md
+++ b/roles/builder/README.md
@@ -105,6 +105,18 @@ This is the path to a location on the osbuild server that the generated
 blueprint should be stored at and used as the source content for the osbuild
 compose build.
 
+### builder_ostree_url
+
+Type: string
+Required: false
+
+This variable is used to pass the ostree repo url of a perviously built commit to build an installer from. When this variable is not defined a new commit will be built for the installer.
+
+Example:
+```yaml
+builder_ostree_url: "http://0.0.0.0/test_blueprint_aap/repo/"
+```
+
 ### builder_blueprint_ref
 
 Type: string

--- a/roles/builder/tasks/main.yml
+++ b/roles/builder/tasks/main.yml
@@ -54,7 +54,7 @@
 
 - name: Check if image directory exists
   ansible.builtin.stat:
-    path: "/var/www/html/{{ builder_blueprint_name }}"
+    path: "/var/www/html/{{ builder_blueprint_name }}/repo"
   register: stat_output
 
 - name: Create image directory is it doesn't exist

--- a/roles/builder/tasks/main.yml
+++ b/roles/builder/tasks/main.yml
@@ -183,8 +183,8 @@
       infra.osbuild.start_compose:
         blueprint: "{{ builder_blueprint_name }}-empty"
         compose_type: "{{ _builder_compose_type }}"
-        ostree_url: "{{ builder_ostree_url if builder_ostree_url is defined else 'http://' + ansible_default_ipv4.address + '/' + builder_blueprint_name + '/repo/' }}"
-        ostree_ref: "{{ builder_blueprint_ref | default(omit) }}" # noqa yaml[line-length]
+        ostree_url: "{{ builder_ostree_url if builder_ostree_url is defined else 'http://' + ansible_default_ipv4.address + '/' + builder_blueprint_name + '/repo/' }}" # noqa yaml[line-length]
+        ostree_ref: "{{ builder_blueprint_ref | default(omit) }}"
       register: compose_start_out
       when:
         - "'edge' in _builder_compose_type or 'iot' in _builder_compose_type"

--- a/roles/builder/tasks/main.yml
+++ b/roles/builder/tasks/main.yml
@@ -23,116 +23,123 @@
     groups: weldr
     append: true
 
-- name: Image build process
+- name: Process when existing commit isn't defined in builder_ostree_url variable
+  # when: builder_ostree_url is not defined
+  when: false
   block:
-    - name: Include enable_custom_repos.yml
-      ansible.builtin.include_tasks:
-        file: enable_custom_repos.yml
-
-    - name: Create a blueprint
-      infra.osbuild.create_blueprint:
-        dest: "{{ builder_blueprint_src_path }}"
-        name: "{{ builder_blueprint_name }}"
-        distro: "{{ builder_blueprint_distro | default(omit) }}"
-        packages: "{{ builder_compose_pkgs }}"
-        customizations: "{{ builder_compose_customizations }}"
-      register: blueprint_output
-
-    - name: Push the blueprint into image builder
-      infra.osbuild.push_blueprint:
-        src: "{{ builder_blueprint_src_path }}"
-
-    - name: Check if blueprint directory exists
-      ansible.builtin.stat:
-        path: "/var/www/html/{{ builder_blueprint_name }}"
-      register: stat_output
-
-    - name: Initialize rpm-ostree repo for blueprint
-      when: not stat_output.stat.exists
+    - name: Image build process
       block:
-        - name: Create blueprint directory
-          ansible.builtin.file:
+        - name: Include enable_custom_repos.yml
+          ansible.builtin.include_tasks:
+            file: enable_custom_repos.yml
+
+        - name: Create a blueprint
+          infra.osbuild.create_blueprint:
+            dest: "{{ builder_blueprint_src_path }}"
+            name: "{{ builder_blueprint_name }}"
+            distro: "{{ builder_blueprint_distro | default(omit) }}"
+            packages: "{{ builder_compose_pkgs }}"
+            customizations: "{{ builder_compose_customizations }}"
+          register: blueprint_output
+
+        - name: Push the blueprint into image builder
+          infra.osbuild.push_blueprint:
+            src: "{{ builder_blueprint_src_path }}"
+
+        - name: Check if blueprint directory exists
+          ansible.builtin.stat:
             path: "/var/www/html/{{ builder_blueprint_name }}"
-            mode: '0755'
-            state: directory
-        - name: Initialize repository
-          ansible.builtin.command:
-            chdir: "/var/www/html/{{ builder_blueprint_name }}"
-            cmd: '/usr/bin/ostree --repo=repo init --mode=archive'
-          args:
-            creates: "/var/www/html/{{ builder_blueprint_name }}/repo"
+          register: stat_output
 
-    - name: Start compose
-      infra.osbuild.start_compose:
-        blueprint: "{{ builder_blueprint_name }}"
-        compose_type: "{{ builder_compose_type }}"
-      register: compose_start_out
+        - name: Initialize rpm-ostree repo for blueprint
+          when: not stat_output.stat.exists
+          block:
+            - name: Create blueprint directory
+              ansible.builtin.file:
+                path: "/var/www/html/{{ builder_blueprint_name }}"
+                mode: '0755'
+                state: directory
+            - name: Initialize repository
+              ansible.builtin.command:
+                chdir: "/var/www/html/{{ builder_blueprint_name }}"
+                cmd: '/usr/bin/ostree --repo=repo init --mode=archive'
+              args:
+                creates: "/var/www/html/{{ builder_blueprint_name }}/repo"
 
-    - name: Wait for compose to finish
-      infra.osbuild.wait_compose:
-        compose_id: "{{ compose_start_out['result']['build_id'] }}"
-  always:
-    - name: Include disable_custom_repos.yml
-      ansible.builtin.include_tasks:
-        file: disable_custom_repos.yml
+        - name: Start compose
+          infra.osbuild.start_compose:
+            blueprint: "{{ builder_blueprint_name }}"
+            compose_type: "{{ builder_compose_type }}"
+          register: compose_start_out
 
-- name: Create tmp directory for blueprint
-  ansible.builtin.file:
-    path: "/tmp/{{ builder_blueprint_name }}"
-    mode: '0755'
-    state: directory
+        - name: Wait for compose to finish
+          infra.osbuild.wait_compose:
+            compose_id: "{{ compose_start_out['result']['build_id'] }}"
+      always:
+        - name: Include disable_custom_repos.yml
+          ansible.builtin.include_tasks:
+            file: disable_custom_repos.yml
 
-- name: Export the compose artifact
-  infra.osbuild.export_compose:
-    compose_id: "{{ compose_start_out['result']['build_id'] }}"
-    dest: "/tmp/{{ builder_blueprint_name }}/{{ builder_blueprint_name }}-{{ blueprint_output['current_version'] }}.{{ compose_start_out['result']['output_type'] }}" # noqa yaml[line-length]
-
-- name: Update ostree repository
-  when: (builder_compose_type == 'edge-commit' or builder_compose_type == 'iot-commit') and (builder_skip_repo is undefined or not builder_skip_repo)
-  block:
-    - name: Untar artifact
-      ansible.builtin.unarchive:
-        src: /tmp/{{ builder_blueprint_name }}/{{ builder_blueprint_name }}-{{ blueprint_output['current_version'] }}.tar
-        dest: /tmp/{{ builder_blueprint_name }}
-        remote_src: true
-
-    - name: Get checksum from artifact
-      ansible.builtin.command:
-        cmd: "/usr/bin/ostree --repo=/tmp/{{ builder_blueprint_name }}/repo rev-parse {{ builder_blueprint_ref }}"
-      register: checksum_output
-      changed_when: false
-
-    - name: Pull commit from artifact
-      ansible.builtin.command:
-        cmd: "/usr/bin/ostree --repo=/var/www/html/{{ builder_blueprint_name }}/repo pull-local /tmp/{{ builder_blueprint_name }}/repo {{ checksum_output['stdout'] }}"
-      changed_when: true
-
-    - name: Commit changes to repository
-      ansible.builtin.command:
-        cmd: "/usr/bin/ostree --repo=/var/www/html/{{ builder_blueprint_name }}/repo commit -b {{ builder_blueprint_ref }} -s 'Release {{ blueprint_output['current_version'] }}' --add-metadata-string=version={{ blueprint_output['current_version'] }} --tree=ref={{ checksum_output['stdout'] }}"
-      changed_when: true
-
-    - name: Remove tar file
+    - name: Create tmp directory for blueprint
       ansible.builtin.file:
-        path: "/tmp/{{ builder_blueprint_name }}/{{ builder_blueprint_name }}-{{ blueprint_output['current_version'] }}.{{ compose_start_out['result']['output_type'] }}"
-        state: absent
-
-- name: Serve all other compose types on the http server
-  when: builder_compose_type != 'edge-commit' and builder_compose_type != 'iot-commit'
-  block:
-    - name: Create images directory
-      ansible.builtin.file:
-        path: "/var/www/html/{{ builder_blueprint_name }}/images"
+        path: "/tmp/{{ builder_blueprint_name }}"
         mode: '0755'
         state: directory
-    - name: Copy image to web dir
-      ansible.builtin.copy:
-        src: "/tmp/{{ builder_blueprint_name }}/{{ builder_blueprint_name }}-{{ blueprint_output['current_version'] }}.{{ compose_start_out['result']['output_type'] }}" # noqa yaml[line-length]
-        dest: "/var/www/html/{{ builder_blueprint_name }}/images/{{ builder_blueprint_name }}_{{ builder_compose_type }}.{{ compose_start_out['result']['output_type'] }}"
-        remote_src: true
-        mode: '0644'
-        owner: apache
-        group: apache
+
+    - name: Export the compose artifact
+      infra.osbuild.export_compose:
+        compose_id: "{{ compose_start_out['result']['build_id'] }}"
+        dest: "/tmp/{{ builder_blueprint_name }}/{{ builder_blueprint_name }}-{{ blueprint_output['current_version'] }}.{{ compose_start_out['result']['output_type'] }}" # noqa yaml[line-length]
+
+    - name: Update ostree repository
+      when: (builder_compose_type == 'edge-commit' or builder_compose_type == 'iot-commit') and (builder_skip_repo is undefined or not builder_skip_repo)
+      block:
+        - name: Untar artifact
+          ansible.builtin.unarchive:
+            src: /tmp/{{ builder_blueprint_name }}/{{ builder_blueprint_name }}-{{ blueprint_output['current_version'] }}.tar
+            dest: /tmp/{{ builder_blueprint_name }}
+            remote_src: true
+
+        - name: Get checksum from artifact
+          ansible.builtin.command:
+            cmd: "/usr/bin/ostree --repo=/tmp/{{ builder_blueprint_name }}/repo rev-parse {{ builder_blueprint_ref }}"
+          register: checksum_output
+          changed_when: false
+
+        - name: Pull commit from artifact
+          ansible.builtin.command:
+            cmd: "/usr/bin/ostree --repo=/var/www/html/{{ builder_blueprint_name }}/repo pull-local /tmp/{{ builder_blueprint_name }}/repo {{ checksum_output['stdout'] }}"
+          changed_when: true
+
+        - name: Commit changes to repository
+          ansible.builtin.command:
+            cmd: "/usr/bin/ostree --repo=/var/www/html/{{ builder_blueprint_name }}/repo commit -b {{ builder_blueprint_ref }} -s 'Release {{ blueprint_output['current_version'] }}' --add-metadata-string=version={{ blueprint_output['current_version'] }} --tree=ref={{ checksum_output['stdout'] }}"
+          changed_when: true
+
+        - name: Remove tar file
+          ansible.builtin.file:
+            path: "/tmp/{{ builder_blueprint_name }}/{{ builder_blueprint_name }}-{{ blueprint_output['current_version'] }}.{{ compose_start_out['result']['output_type'] }}"
+            state: absent
+
+    - name: Serve all other compose types on the http server
+      when: builder_compose_type != 'edge-commit' and builder_compose_type != 'iot-commit'
+      block:
+        - name: Create images directory
+          ansible.builtin.file:
+            path: "/var/www/html/{{ builder_blueprint_name }}/images"
+            mode: '0755'
+            state: directory
+        - name: Copy image to web dir
+          ansible.builtin.copy:
+            src: "/tmp/{{ builder_blueprint_name }}/{{ builder_blueprint_name }}-{{ blueprint_output['current_version'] }}.{{ compose_start_out['result']['output_type'] }}" # noqa yaml[line-length]
+            dest: "/var/www/html/{{ builder_blueprint_name }}/images/{{ builder_blueprint_name }}_{{ builder_compose_type }}.{{ compose_start_out['result']['output_type'] }}"
+            remote_src: true
+            mode: '0644'
+            owner: apache
+            group: apache
+    - name: Restore context on blueprint directory
+      ansible.builtin.command: "restorecon -R /var/www/html/{{ builder_blueprint_name }}"
+      changed_when: true
 
 - name: Create kickstart file
   ansible.builtin.template:
@@ -143,10 +150,6 @@
 - name: Validate kickstart
   ansible.builtin.command: "/usr/bin/ksvalidator /var/www/html/{{ builder_blueprint_name }}/kickstart.ks"
   changed_when: false
-
-- name: Restore context on blueprint directory
-  ansible.builtin.command: "restorecon -R /var/www/html/{{ builder_blueprint_name }}"
-  changed_when: true
 
 - name: Create installer
   when:
@@ -181,7 +184,7 @@
       infra.osbuild.start_compose:
         blueprint: "{{ builder_blueprint_name }}-empty"
         compose_type: "{{ _builder_compose_type }}"
-        ostree_url: "http://{{ ansible_default_ipv4.address }}/{{ builder_blueprint_name }}/repo/"
+        ostree_url: "{{ builder_ostree_url if builder_ostree_url is defined else 'http://' + ansible_default_ipv4.address + '/' + builder_blueprint_name + '/repo/' }}"
         ostree_ref: "{{ builder_blueprint_ref | default(omit) }}"
       register: compose_start_out
       when:

--- a/roles/builder/tasks/main.yml
+++ b/roles/builder/tasks/main.yml
@@ -23,6 +23,20 @@
     groups: weldr
     append: true
 
+- name: Check if image directory exists
+  ansible.builtin.stat:
+    path: "/var/www/html/{{ builder_blueprint_name }}"
+  register: stat_output
+
+- name: Create image directory is it doesn't exist
+  when: not stat_output.stat.exists
+  block:
+    - name: Create blueprint directory
+      ansible.builtin.file:
+        path: "/var/www/html/{{ builder_blueprint_name }}"
+        mode: '0755'
+        state: directory
+
 - name: Process when existing commit isn't defined in builder_ostree_url variable
   when: builder_ostree_url is not defined
   block:
@@ -45,19 +59,9 @@
           infra.osbuild.push_blueprint:
             src: "{{ builder_blueprint_src_path }}"
 
-        - name: Check if blueprint directory exists
-          ansible.builtin.stat:
-            path: "/var/www/html/{{ builder_blueprint_name }}"
-          register: stat_output
-
         - name: Initialize rpm-ostree repo for blueprint
           when: not stat_output.stat.exists
           block:
-            - name: Create blueprint directory
-              ansible.builtin.file:
-                path: "/var/www/html/{{ builder_blueprint_name }}"
-                mode: '0755'
-                state: directory
             - name: Initialize repository
               ansible.builtin.command:
                 chdir: "/var/www/html/{{ builder_blueprint_name }}"

--- a/roles/builder/tasks/main.yml
+++ b/roles/builder/tasks/main.yml
@@ -24,8 +24,7 @@
     append: true
 
 - name: Process when existing commit isn't defined in builder_ostree_url variable
-  # when: builder_ostree_url is not defined
-  when: false
+  when: builder_ostree_url is not defined
   block:
     - name: Image build process
       block:

--- a/roles/builder/tasks/main.yml
+++ b/roles/builder/tasks/main.yml
@@ -184,7 +184,7 @@
         blueprint: "{{ builder_blueprint_name }}-empty"
         compose_type: "{{ _builder_compose_type }}"
         ostree_url: "{{ builder_ostree_url if builder_ostree_url is defined else 'http://' + ansible_default_ipv4.address + '/' + builder_blueprint_name + '/repo/' }}"
-        ostree_ref: "{{ builder_blueprint_ref | default(omit) }}"
+        ostree_ref: "{{ builder_blueprint_ref | default(omit) }}" # noqa yaml[line-length]
       register: compose_start_out
       when:
         - "'edge' in _builder_compose_type or 'iot' in _builder_compose_type"


### PR DESCRIPTION
Add builder_ostree_url variable to build installer with existing commit.
This will allow for building an installer with an existing commit and skip building a commit.
This was created to resolve issue #119 