### PR TITLE
Add distro to empty blueprint

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -541,17 +541,16 @@ stages:
           groups:
             - 5
 
-      # Fixme
-      # - template: templates/matrix.yml
-      #   parameters:
-      #     testFormat: 2.13/{0}
-      #     targets:
-      #       - name: RHEL 9.0 edge-installer
-      #         test: rhel/9.0
-      #       - name: RHEL 8.5 edge-installer
-      #         test: rhel/8.5
-      #     groups:
-      #       - 6
+      - template: templates/matrix.yml
+        parameters:
+          testFormat: 2.13/{0}
+          targets:
+            - name: RHEL 9.0 edge-installer
+              test: rhel/9.0
+            - name: RHEL 8.5 edge-installer
+              test: rhel/8.5
+          groups:
+            - 6
 
       # Fixme
       # - template: templates/matrix.yml

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -541,16 +541,17 @@ stages:
           groups:
             - 5
 
-      - template: templates/matrix.yml
-        parameters:
-          testFormat: 2.13/{0}
-          targets:
-            - name: RHEL 9.0 edge-installer
-              test: rhel/9.0
-            - name: RHEL 8.5 edge-installer
-              test: rhel/8.5
-          groups:
-            - 6
+      # Fixme
+      # - template: templates/matrix.yml
+      #   parameters:
+      #     testFormat: 2.13/{0}
+      #     targets:
+      #       - name: RHEL 9.0 edge-installer
+      #         test: rhel/9.0
+      #       - name: RHEL 8.5 edge-installer
+      #         test: rhel/8.5
+      #     groups:
+      #       - 6
 
       # Fixme
       # - template: templates/matrix.yml

--- a/roles/builder/tasks/main.yml
+++ b/roles/builder/tasks/main.yml
@@ -192,6 +192,7 @@
       infra.osbuild.create_blueprint:
         dest: "{{ builder_blueprint_src_path }}"
         name: "{{ builder_blueprint_name }}-empty"
+        distro: "{{ builder_blueprint_distro | default(omit) }}"
       register: blueprint_output
       when:
         - "'edge' in _builder_compose_type or 'iot' in _builder_compose_type"


### PR DESCRIPTION
Add distro to empty blueprint to allow for building different installer than the build machine distro