### PR TITLE
Fix weldr post compose

### DIFF
--- a/plugins/module_utils/weldrapiv1.py
+++ b/plugins/module_utils/weldrapiv1.py
@@ -296,7 +296,7 @@ class WeldrV1:
         )
         result = dict()
         result["status_code"] = info["status"]
-        if info["status_code"] < 400:
+        if result["status_code"] < 400:
             result["body"] = json.loads(response.read().decode("utf-8"))
         else:
             result["body"] = info["body"]


### PR DESCRIPTION
# Description
The `info` dict doesn't have the key status_code so this fix replaces it with the `result`.

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor
