### PR TITLE
added system_info role

### DIFF
--- a/changelogs/fragments/172-get-system-info.yaml
+++ b/changelogs/fragments/172-get-system-info.yaml
@@ -1,0 +1,2 @@
+major_changes:
+  - system_info - created new role to gather information from a running rpm-ostree based system

--- a/playbooks/osbuild_system_info.yaml
+++ b/playbooks/osbuild_system_info.yaml
@@ -6,6 +6,6 @@
       ansible.builtin.import_role:
         name: infra.osbuild.system_info
 
-    - name: debug
+    - name: Debug system info
       ansible.builtin.debug:
-        msg: "{{ ansible_facts['rpm_ostree'] }}"
+        msg: "{{ ansible_facts['system_info_rpm_ostree'] }}"

--- a/playbooks/osbuild_system_info.yaml
+++ b/playbooks/osbuild_system_info.yaml
@@ -1,0 +1,11 @@
+---
+- name: Get system info
+  hosts: all
+  tasks:
+    - name: Use system role to get image version
+      ansible.builtin.import_role:
+        name: infra.osbuild.system_info
+
+    - name: debug
+      ansible.builtin.debug:
+        msg: "{{ ansible_facts['rpm_ostree'] }}"

--- a/playbooks/osbuild_system_info.yaml
+++ b/playbooks/osbuild_system_info.yaml
@@ -8,4 +8,4 @@
 
     - name: Debug system info
       ansible.builtin.debug:
-        msg: "{{ ansible_facts['system_info_rpm_ostree'] }}"
+        msg: "{{ ansible_facts['rpm_ostree'] }}"

--- a/roles/system_info/README.md
+++ b/roles/system_info/README.md
@@ -1,0 +1,38 @@
+Role Name
+=========
+
+A brief description of the role goes here.
+
+Requirements
+------------
+
+Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+
+Role Variables
+--------------
+
+A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+
+Dependencies
+------------
+
+A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+
+Example Playbook
+----------------
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+    - hosts: servers
+      roles:
+         - { role: username.rolename, x: 42 }
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+An optional section for the role authors to include contact information, or a website (HTML is not allowed).

--- a/roles/system_info/README.md
+++ b/roles/system_info/README.md
@@ -29,7 +29,7 @@ None.
 
     - name: debug
       ansible.builtin.debug:
-        msg: "{{ ansible_facts['rpm_ostree'] }}"
+        msg: "{{ ansible_facts['system_info_rpm_ostree'] }}"
 ```
 
 

--- a/roles/system_info/README.md
+++ b/roles/system_info/README.md
@@ -1,38 +1,40 @@
-Role Name
-=========
+# infra.osbuild.system_info
 
-A brief description of the role goes here.
+This role automates the gathering of information from a running rpm-ostree based system.
 
-Requirements
-------------
+## Requirements
 
-Any pre-requisites that may not be covered by Ansible itself or the role should be mentioned here. For instance, if the role uses the EC2 module, it may be a good idea to mention in this section that the boto package is required.
+None
 
-Role Variables
---------------
+## Role Variables
 
-A description of the settable variables for this role should go here, including any variables that are in defaults/main.yml, vars/main.yml, and any variables that can/should be set via parameters to the role. Any variables that are read from other roles and/or the global scope (ie. hostvars, group vars, etc.) should be mentioned here as well.
+## Variables Exported by the Role
 
-Dependencies
-------------
+None.
 
-A list of other roles hosted on Galaxy should go here, plus any details in regards to parameters that may need to be set for other roles, or variables that are used from other roles.
+## Dependencies
 
-Example Playbook
-----------------
+None.
 
-Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+## Example Playbook
 
-    - hosts: servers
-      roles:
-         - { role: username.rolename, x: 42 }
+```yaml
+---
+- name: Get system info
+  hosts: all
+  tasks:
+    - name: Use system role to get image version
+      ansible.builtin.import_role:
+        name: infra.osbuild.system_info
 
-License
--------
+    - name: debug
+      ansible.builtin.debug:
+        msg: "{{ ansible_facts['rpm_ostree'] }}"
+```
 
-BSD
 
-Author Information
-------------------
+## License
 
-An optional section for the role authors to include contact information, or a website (HTML is not allowed).
+GPLv3
+
+

--- a/roles/system_info/README.md
+++ b/roles/system_info/README.md
@@ -29,7 +29,7 @@ None.
 
     - name: debug
       ansible.builtin.debug:
-        msg: "{{ ansible_facts['system_info_rpm_ostree'] }}"
+        msg: "{{ ansible_facts['rpm_ostree'] }}"
 ```
 
 

--- a/roles/system_info/defaults/main.yml
+++ b/roles/system_info/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for system_info

--- a/roles/system_info/handlers/main.yml
+++ b/roles/system_info/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for system_info

--- a/roles/system_info/meta/main.yml
+++ b/roles/system_info/meta/main.yml
@@ -1,0 +1,52 @@
+galaxy_info:
+  author: your name
+  description: your role description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
+  # - MIT
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
+  license: license (GPL-2.0-or-later, MIT, etc)
+
+  min_ansible_version: 2.1
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/roles/system_info/meta/main.yml
+++ b/roles/system_info/meta/main.yml
@@ -1,52 +1,23 @@
+---
 galaxy_info:
-  author: your name
-  description: your role description
-  company: your company (optional)
-
-  # If the issue tracker for your role is not on github, uncomment the
-  # next line and provide a value
-  # issue_tracker_url: http://example.com/issue/tracker
-
-  # Choose a valid license ID from https://spdx.org - some suggested licenses:
-  # - BSD-3-Clause (default)
-  # - MIT
-  # - GPL-2.0-or-later
-  # - GPL-3.0-only
-  # - Apache-2.0
-  # - CC-BY-4.0
-  license: license (GPL-2.0-or-later, MIT, etc)
-
-  min_ansible_version: 2.1
-
-  # If this a Container Enabled role, provide the minimum Ansible Container version.
-  # min_ansible_container_version:
-
-  #
-  # Provide a list of supported platforms, and for each platform a list of versions.
-  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
-  # To view available platforms and versions (or releases), visit:
-  # https://galaxy.ansible.com/api/v1/platforms/
-  #
-  # platforms:
-  # - name: Fedora
-  #   versions:
-  #   - all
-  #   - 25
-  # - name: SomePlatform
-  #   versions:
-  #   - all
-  #   - 1.0
-  #   - 7
-  #   - 99.99
-
-  galaxy_tags: []
-    # List tags for your role here, one per line. A tag is a keyword that describes
-    # and categorizes the role. Users find roles by searching for tags. Be sure to
-    # remove the '[]' above, if you add tags to this list.
-    #
-    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
-    #       Maximum 20 tags per role.
-
+  role_name: "system_info"
+  standalone: false
+  company: "Red Hat"
+  description: >
+    Gather information from a rpm-ostree based system
+  author: Ansible Edge Working Group
+  license: "GPL-3.0-or-later"
+  min_ansible_version: "2.12"
+  platforms:
+    - name: EL
+      versions:
+        - "8"
+        - "9"
+    - name: Fedora
+      versions:
+        - all
+  galaxy_tags:
+    - image
+    - build
+    - os
 dependencies: []
-  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
-  # if you add dependencies to this list.

--- a/roles/system_info/tasks/main.yml
+++ b/roles/system_info/tasks/main.yml
@@ -10,7 +10,7 @@
     system_info_json: "{{ system_info_output.stdout | from_json }}"
   ansible.builtin.set_fact:
     cacheable: true # noqa var-naming[no-role-prefix]
-    system_info_rpm_ostree:
+    rpm_ostree:
       - current:
           version: "{{ system_info_json['deployments'][0]['version'] }}"
           checksum: "{{ system_info_json['deployments'][0]['checksum'] }}"

--- a/roles/system_info/tasks/main.yml
+++ b/roles/system_info/tasks/main.yml
@@ -1,0 +1,18 @@
+---
+# tasks file for system_info
+- name: Get system info
+  ansible.builtin.command: '/usr/bin/rpm-ostree status --json'
+  register: rpm_ostree_status_output
+
+- name: Set rpm-ostree facts on system
+  vars:
+    json_output: "{{ rpm_ostree_status_output.stdout | from_json }}"
+  ansible.builtin.set_fact:
+    cacheable: true
+    rpm_ostree:
+      - current:
+          version: "{{ json_output['deployments'][0]['version'] }}"
+          checksum: "{{ json_output['deployments'][0]['checksum'] }}"
+      - rollback:
+          version: "{{ json_output['deployments'][1]['version'] }}"
+          checksum: "{{ json_output['deployments'][1]['checksum'] }}"

--- a/roles/system_info/tasks/main.yml
+++ b/roles/system_info/tasks/main.yml
@@ -2,6 +2,7 @@
 # tasks file for system_info
 - name: Get system info
   ansible.builtin.command: '/usr/bin/rpm-ostree status --json'
+  changed_when: false
   register: rpm_ostree_status_output
 
 - name: Set rpm-ostree facts on system

--- a/roles/system_info/tasks/main.yml
+++ b/roles/system_info/tasks/main.yml
@@ -3,17 +3,17 @@
 - name: Get system info
   ansible.builtin.command: '/usr/bin/rpm-ostree status --json'
   changed_when: false
-  register: rpm_ostree_status_output
+  register: system_info_output
 
 - name: Set rpm-ostree facts on system
   vars:
-    json_output: "{{ rpm_ostree_status_output.stdout | from_json }}"
+    system_info_json: "{{ system_info_output.stdout | from_json }}"
   ansible.builtin.set_fact:
-    cacheable: true
-    rpm_ostree:
+    cacheable: true # noqa var-naming[no-role-prefix]
+    system_info_rpm_ostree:
       - current:
-          version: "{{ json_output['deployments'][0]['version'] }}"
-          checksum: "{{ json_output['deployments'][0]['checksum'] }}"
+          version: "{{ system_info_json['deployments'][0]['version'] }}"
+          checksum: "{{ system_info_json['deployments'][0]['checksum'] }}"
       - rollback:
-          version: "{{ json_output['deployments'][1]['version'] }}"
-          checksum: "{{ json_output['deployments'][1]['checksum'] }}"
+          version: "{{ system_info_json['deployments'][1]['version'] }}"
+          checksum: "{{ system_info_json['deployments'][1]['checksum'] }}"

--- a/roles/system_info/tests/inventory
+++ b/roles/system_info/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/roles/system_info/tests/test.yml
+++ b/roles/system_info/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - system_info

--- a/roles/system_info/tests/test.yml
+++ b/roles/system_info/tests/test.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: localhost
+- name: Run test for the system_info role
+  hosts: localhost
   remote_user: root
   roles:
     - system_info

--- a/roles/system_info/vars/main.yml
+++ b/roles/system_info/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for system_info


### PR DESCRIPTION
# Description
Added the `system_info` role to query rpm-ostree based running systems for info (version, commit)

FIXES: <!-- AAP-NNNN -->

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor
