### PR TITLE
AAP-12417 remove copy the iso file on tests

### DIFF
--- a/tests/integration/targets/compose_type-edge_container/tasks/tests.yml
+++ b/tests/integration/targets/compose_type-edge_container/tasks/tests.yml
@@ -15,11 +15,3 @@
   ansible.builtin.assert:
     that:
       - container_stat_result.stat.exists
-
-- name: Create output/bot directory
-  ansible.builtin.command: mkdir -p /root/ansible_collections/infra/osbuild/tests/output/bot/
-  changed_when: true
-
-- name: Copy image
-  ansible.builtin.command: mv /var/www/html/{{ builder_blueprint_name }}/images/0.0.1/{{ builder_blueprint_name }}_edge-container.tar /root/ansible_collections/infra/osbuild/tests/output/bot/ # noqa yaml[line-length]
-  changed_when: true

--- a/tests/integration/targets/compose_type-edge_installer/tasks/tests.yml
+++ b/tests/integration/targets/compose_type-edge_installer/tasks/tests.yml
@@ -15,11 +15,3 @@
   ansible.builtin.assert:
     that:
       - edge_installer_stat_result.stat.exists
-
-- name: Create output/bot directory
-  ansible.builtin.command: mkdir -p /root/ansible_collections/infra/osbuild/tests/output/bot/
-  changed_when: true
-
-- name: Copy image
-  ansible.builtin.command: mv /var/www/html/{{ builder_blueprint_name }}/images/{{ builder_blueprint_name }}_edge-installer.iso /root/ansible_collections/infra/osbuild/tests/output/bot/ # noqa yaml[line-length]
-  changed_when: true

--- a/tests/integration/targets/compose_type-edge_simplified_installer/tasks/tests.yml
+++ b/tests/integration/targets/compose_type-edge_simplified_installer/tasks/tests.yml
@@ -15,11 +15,3 @@
   ansible.builtin.assert:
     that:
       - edge_simplified_installer_stat_result.stat.exists
-
-- name: Create output/bot directory
-  ansible.builtin.command: mkdir -p /root/ansible_collections/infra/osbuild/tests/output/bot/
-  changed_when: true
-
-- name: Copy image
-  ansible.builtin.command: mv /var/www/html/{{ builder_blueprint_name }}/images/0.0.1/{{ builder_blueprint_name }}_{{ builder_compose_type }}.iso /root/ansible_collections/infra/osbuild/tests/output/bot/ # noqa yaml[line-length]
-  changed_when: true

--- a/tests/integration/targets/compose_type-image_installer/tasks/tests.yml
+++ b/tests/integration/targets/compose_type-image_installer/tasks/tests.yml
@@ -15,11 +15,3 @@
   ansible.builtin.assert:
     that:
       - image_installer_stat_result.stat.exists
-
-- name: Create output/bot directory
-  ansible.builtin.command: mkdir -p /root/ansible_collections/infra/osbuild/tests/output/bot/
-  changed_when: true
-
-- name: Copy image
-  ansible.builtin.command: mv /var/www/html/{{ builder_blueprint_name }}/images/0.0.1/{{ builder_blueprint_name }}_image-installer.iso /root/ansible_collections/infra/osbuild/tests/output/bot/ # noqa yaml[line-length]
-  changed_when: true


### PR DESCRIPTION
# Description
Recome copy the iso file on tests due because it's not present in the directory anymore and those iso will not be required since the osbuild builder server is ephemeral.

FIXES: [AAP-12417](https://issues.redhat.com/browse/AAP-12417)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Tests update
- [ ] Refactor
