### PR TITLE
Add fdo and installation_device to installer blueprint, skip inject ks for simplified installers

### DIFF
--- a/roles/builder/tasks/main.yml
+++ b/roles/builder/tasks/main.yml
@@ -196,9 +196,35 @@
         dest: "{{ builder_blueprint_src_path }}"
         name: "{{ builder_blueprint_name }}-empty"
         distro: "{{ builder_blueprint_distro | default(omit) }}"
-      register: builder_blueprint_output
+      register: __builder_blueprint_output
       when:
-        - "'edge' in builder_compose_type or 'iot' in builder_compose_type"
+        - "'simplified' not in builder_compose_type and 'edge' in builder_compose_type or 'iot' in builder_compose_type"
+
+    - name: Create simplified installer blueprint
+      block:
+        - name: Create __simplified_insaller_customizations var
+          ansible.builtin.set_fact: 
+            __simplified_insaller_customizations: {}
+
+        - name: Set _simplified_insaller_customizations value including only fdo and installation_device customizations
+          ansible.builtin.set_fact: 
+            __simplified_insaller_customizations: "{{ __simplified_insaller_customizations | combine({item.key: item.value}) }}"
+          when: "{{ item.key in ['fdo', 'installation_device'] }}"
+          with_dict: "{{ builder_compose_customizations }}"
+
+        - name: Create simplified installer blueprint
+          infra.osbuild.create_blueprint:
+            dest: "{{ builder_blueprint_src_path }}"
+            name: "{{ builder_blueprint_name }}-empty"
+            distro: "{{ builder_blueprint_distro | default(omit) }}"
+            customizations: "{{ __simplified_insaller_customizations }}"
+          register: __builder_blueprint_output_simplified
+      when:
+        - "'simplified' in builder_compose_type and 'edge' in builder_compose_type or 'iot' in builder_compose_type"
+
+    - name: Set builder_blueprint_output
+      ansible.builtin.set_fact:
+        builder_blueprint_output: "{{ __builder_blueprint_output if __builder_blueprint_output['current_version'] is defined else __builder_blueprint_output_simplified }}"
 
     - name: Push the blueprint into image builder
       infra.osbuild.push_blueprint:
@@ -253,10 +279,12 @@
         kickstart: "/var/www/html/{{ builder_blueprint_name }}/kickstart.ks"
         src_iso: "/tmp/{{ builder_blueprint_name }}/{{ builder_blueprint_name }}-{{ builder_blueprint_output['current_version'] }}.{{ builder_compose_start_out['result']['output_type'] }}"  # noqa yaml[line-length]
         dest_iso: "/tmp/{{ builder_blueprint_name }}/{{ builder_blueprint_name }}-{{ builder_blueprint_output['current_version'] }}_ks.{{ builder_compose_start_out['result']['output_type'] }}"  # noqa yaml[line-length]
+      when:
+        - "'simplified' not in builder_compose_type"
 
     - name: Copy installer to web dir
       ansible.builtin.copy:
-        src: "/tmp/{{ builder_blueprint_name }}/{{ builder_blueprint_name }}-{{ builder_blueprint_output['current_version'] }}_ks.{{ builder_compose_start_out['result']['output_type'] }}"  # noqa yaml[line-length]
+        src: "/tmp/{{ builder_blueprint_name }}/{{ builder_blueprint_name }}-{{ builder_blueprint_output['current_version'] }}{{ '_ks' if 'simplified' not in builder_compose_type }}.{{ builder_compose_start_out['result']['output_type'] }}"  # noqa yaml[line-length]
         dest: "/var/www/html/{{ builder_blueprint_name }}/images/{{ builder_blueprint_output['current_version'] }}/{{ builder_blueprint_name }}_{{ builder_compose_type }}.{{ builder_compose_start_out['result']['output_type'] }}"  # noqa yaml[line-length]
 
         remote_src: true

--- a/roles/update_system/tasks/main.yml
+++ b/roles/update_system/tasks/main.yml
@@ -1,7 +1,6 @@
 ---
 # tasks file for roles/update_system
 - name: Update system to the latest commit
-  # ansible.builtin.command: '/usr/bin/rpm-ostree upgrade'
   ansible.posix.rpm_ostree_upgrade:
   register: update_system_output
 


### PR DESCRIPTION

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->
Add fdo and installation_device to installer blueprint, skip inject ks for simplified installers.
simplified_installers need fdo and installation_device added to the installer blueprint to properly build and shouldn't have a kickstart file injected into the iso.

FIXES: <!-- AAP-NNNN -->

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor
