### PR TITLE
AAP-12882 fix yamllint line-length too long

### DIFF
--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -11,4 +11,5 @@ jobs:
         run: pip install yamllint
 
       - name: Lint YAML files
-        run: yamllint .
+        run: |
+          yamllint -d "{extends: default, rules: {line-length: {max: 200, level: warning}}}" .


### PR DESCRIPTION
# Description
Fixing yamllint line-length too long

FIXES: [AAP-12882](https://issues.redhat.com/browse/AAP-12882)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor
