### PR TITLE
AAP-12897 sync yamllint blue-green and increase line-length to 350

### DIFF
--- a/.github/workflows/yamllint_blue.yml
+++ b/.github/workflows/yamllint_blue.yml
@@ -1,5 +1,11 @@
 ---
-on: push  # yamllint disable-line rule:truthy
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   lint:
@@ -12,4 +18,4 @@ jobs:
 
       - name: Lint YAML files
         run: |
-          yamllint -d "{extends: default, rules: {line-length: {max: 200, level: warning}}}" .
+          yamllint -d "{extends: default, rules: {line-length: {max: 350, level: warning}}}" .


### PR DESCRIPTION
# Description
sync yamllint blue-green and increase line-length to 350 to clear the warning

FIXES: [AAP-12897](https://issues.redhat.com/browse/AAP-12897)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor
