### PR TITLE
Clear Package Cache When Sources are Modified

### DIFF
--- a/roles/builder/handlers/main.yml
+++ b/roles/builder/handlers/main.yml
@@ -1,2 +1,16 @@
 ---
 # handlers file for builder
+
+- name: clear the package cache
+  ansible.builtin.file:
+    path: /var/cache/osbuild-composer/rpmmd
+    state: absent
+  listen:
+    - __clear_package_cache
+
+- name: restart services
+  ansible.builtin.systemd:
+    name: osbuild-composer.service
+    state: restarted
+  listen:
+    - __restart_services

--- a/roles/builder/tasks/disable_custom_repos.yml
+++ b/roles/builder/tasks/disable_custom_repos.yml
@@ -23,6 +23,9 @@
       loop: "{{ builder_custom_repos }}"
       loop_control:
         loop_var: __builder_repo
+      notify:
+        - __clear_package_cache
+        - __restart_services
 
 - name: Remove source for additional RHSM packages
   when:
@@ -41,3 +44,9 @@
       loop: "{{ __builder_rhsm_repos_info['rhsm_info'] }}"
       loop_control:
         loop_var: __builder_rhsm_repo
+      notify:
+        - __clear_package_cache
+        - __restart_services
+
+- name: flush handlers
+  ansible.builtin.meta: flush_handlers

--- a/roles/builder/tasks/enable_custom_repos.yml
+++ b/roles/builder/tasks/enable_custom_repos.yml
@@ -22,6 +22,9 @@
       loop: "{{ builder_custom_repos }}"
       loop_control:
         loop_var: __builder_repo
+      notify:
+        - __clear_package_cache
+        - __restart_services
 
 - name: Add RHSM repos for additional Red Hat packages
   when:
@@ -46,3 +49,9 @@
       loop: "{{ __builder_rhsm_repos_info['rhsm_info'] }}"
       loop_control:
         loop_var: __builder_rhsm_repo
+      notify:
+        - __clear_package_cache
+        - __restart_services
+
+- name: flush handlers
+  ansible.builtin.meta: flush_handlers


### PR DESCRIPTION
# Description
This PR adds some additional steps to the builder role: as souces are enabled/disabled, the package cache should be cleared out and the service restarted.

This may cause more instances of [this issue](https://github.com/redhat-cop/infra.osbuild/issues/182), however it does prevent depsolve issues when adding sources for composes.

FIXES: <!-- AAP-NNNN -->

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor
