### PR TITLE
Aws support

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -3,3 +3,4 @@ collections:
   - community.general
   - ansible.posix
   - community.libvirt
+  - amazon.aws

--- a/roles/builder/defaults/main.yml
+++ b/roles/builder/defaults/main.yml
@@ -3,7 +3,7 @@ builder_blueprint_name: test_blueprint
 builder_blueprint_src_path: /tmp/blueprint.toml
 builder_blueprint_distro_lower: "{{ 'rhel' if ansible_distribution == 'RedHat' else ansible_distribution | lower }}"
 builder_blueprint_ref: "{{ builder_blueprint_distro_lower }}/{{ hostvars[inventory_hostname].ansible_distribution_major_version }}/x86_64/{{ 'iot' if ansible_distribution == 'Fedora' else 'edge' }}" # noqa yaml[line-length]
-builder_compose_type: edge-commit
+builder_compose_type: edge-installer
 builder_pub_key_path: "~/.ssh/id_rsa.pub"
 builder_password: openshift
 builder_enforce_auth: true
@@ -11,8 +11,6 @@ builder_compose_pkgs:
   - "vim-enhanced"
   - "git"
   - "ansible-core"
-  - "tmux"
-  - "emacs"
 builder_compose_customizations:
   user:
     name: "core"

--- a/roles/builder/defaults/main.yml
+++ b/roles/builder/defaults/main.yml
@@ -3,7 +3,7 @@ builder_blueprint_name: test_blueprint
 builder_blueprint_src_path: /tmp/blueprint.toml
 builder_blueprint_distro_lower: "{{ 'rhel' if ansible_distribution == 'RedHat' else ansible_distribution | lower }}"
 builder_blueprint_ref: "{{ builder_blueprint_distro_lower }}/{{ hostvars[inventory_hostname].ansible_distribution_major_version }}/x86_64/{{ 'iot' if ansible_distribution == 'Fedora' else 'edge' }}" # noqa yaml[line-length]
-builder_compose_type: edge-installer
+builder_compose_type: edge-commit
 builder_pub_key_path: "~/.ssh/id_rsa.pub"
 builder_password: openshift
 builder_enforce_auth: true
@@ -11,6 +11,8 @@ builder_compose_pkgs:
   - "vim-enhanced"
   - "git"
   - "ansible-core"
+  - "tmux"
+  - "emacs"
 builder_compose_customizations:
   user:
     name: "core"
@@ -22,3 +24,5 @@ builder_compose_customizations:
       - "wheel"
 builder_image_storage_threshold: 3 # percentage
 builder_image_storage_cleared: false
+builder_system_ipv4: "{{ ansible_default_ipv4.address }}"
+is_aws_ec2: true

--- a/roles/builder/defaults/main.yml
+++ b/roles/builder/defaults/main.yml
@@ -23,4 +23,3 @@ builder_compose_customizations:
 builder_image_storage_threshold: 3  # percentage
 builder_image_storage_cleared: false
 builder_system_ipv4: "{{ ansible_default_ipv4.address }}"
-is_aws_ec2: true

--- a/roles/builder/tasks/main.yml
+++ b/roles/builder/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
 - name: Set fact system internal ipv4 to public ec2 ipv4
-  when: is_aws_ec2 is defined and is_aws_ec2
+  when: "'ec2' in ansible_facts['domain']"
   block:
     - amazon.aws.ec2_metadata_facts:
 
-    - name: set stuff
+    - name: Set new builder system ipv4 address
       ansible.builtin.set_fact:
         builder_system_ipv4: "{{ ansible_ec2_public_ipv4 }}"
 

--- a/roles/builder/tasks/main.yml
+++ b/roles/builder/tasks/main.yml
@@ -1,4 +1,13 @@
 ---
+- name: Set fact system internal ipv4 to public ec2 ipv4
+  when: is_aws_ec2 is defined and is_aws_ec2
+  block:
+    - amazon.aws.ec2_metadata_facts:
+
+    - name: set stuff
+      ansible.builtin.set_fact:
+        builder_system_ipv4: "{{ ansible_ec2_public_ipv4 }}"
+
 - name: Remove all images from storage
   when: builder_image_storage_cleared
   block:
@@ -236,7 +245,7 @@
       infra.osbuild.start_compose:
         blueprint: "{{ builder_blueprint_name }}"
         compose_type: "{{ builder_compose_type }}"
-        ostree_url: "{{ builder_ostree_url if builder_ostree_url is defined else 'http://' + ansible_default_ipv4.address + '/' + builder_blueprint_name + '/repo/' }}"  # noqa yaml[line-length]
+        ostree_url: "{{ builder_ostree_url if builder_ostree_url is defined else 'http://' + builder_system_ipv4 + '/' + builder_blueprint_name + '/repo/' }}"  # noqa yaml[line-length]
         ostree_ref: "{{ builder_blueprint_ref | default(omit) }}"
       register: builder_compose_start_out
       when:
@@ -246,7 +255,7 @@
       infra.osbuild.start_compose:
         blueprint: "{{ builder_blueprint_name }}-empty"
         compose_type: "{{ builder_compose_type }}"
-        ostree_url: "{{ builder_ostree_url if builder_ostree_url is defined else 'http://' + ansible_default_ipv4.address + '/' + builder_blueprint_name + '/repo/' }}"  # noqa yaml[line-length]
+        ostree_url: "{{ builder_ostree_url if builder_ostree_url is defined else 'http://' + builder_system_ipv4 + '/' + builder_blueprint_name + '/repo/' }}"  # noqa yaml[line-length]
         ostree_ref: "{{ builder_blueprint_ref | default(omit) }}"
       register: builder_compose_start_out
       when:

--- a/roles/builder/tasks/main.yml
+++ b/roles/builder/tasks/main.yml
@@ -2,7 +2,8 @@
 - name: Set fact system internal ipv4 to public ec2 ipv4
   when: "'ec2' in ansible_facts['domain']"
   block:
-    - amazon.aws.ec2_metadata_facts:
+    - name: Gather ec2 metadata facts
+      amazon.aws.ec2_metadata_facts:
 
     - name: Set new builder system ipv4 address
       ansible.builtin.set_fact:

--- a/roles/builder/vars/main.yml
+++ b/roles/builder/vars/main.yml
@@ -11,7 +11,7 @@ builder_kickstart_options:
   - reboot
   - network --bootproto=dhcp
   - services --enabled=ostree-remount
-  - ostreesetup --nogpg --osname=rhel --remote=edge --url=http://{{ ansible_facts["default_ipv4"]["address"] }}/{{ builder_blueprint_name }}/repo/ --ref={{ builder_blueprint_ref }} # noqa yaml[line-length]
+  - ostreesetup --nogpg --osname=rhel --remote=edge --url=http://{{ builder_system_ipv4 }}/{{ builder_blueprint_name }}/repo/ --ref={{ builder_blueprint_ref }} # noqa yaml[line-length]
 _builder_kickstart_post:
   - "{{ lookup('ansible.builtin.template', '../templates/auto_register_aap.j2') if builder_aap_url is defined | default(None) }}"
 builder_kickstart_post: "{{ _builder_kickstart_post + additional_kickstart_post if additional_kickstart_post is defined else _builder_kickstart_post }}"

--- a/tests/utils/shippable/shippable.sh
+++ b/tests/utils/shippable/shippable.sh
@@ -99,6 +99,9 @@ if [ "${script}" != "sanity" ] && [ "${script}" != "units" ] && [ "${test}" != "
 
     # retry ansible-galaxy -vvv collection install community.libvirt
     retry git clone --depth=1 --single-branch --single-branch https://github.com/ansible-collections/community.libvirt.git "${ANSIBLE_COLLECTIONS_PATHS}/ansible_collections/community/libvirt"
+
+    # retry ansible-galaxy -vvv collection install amazon.aws
+    retry git clone --depth=1 --single-branch --single-branch https://github.com/ansible-collections/amazon.aws.git "${ANSIBLE_COLLECTIONS_PATHS}/ansible_collections/amazon/aws"
 fi
 
 # END: HACK


### PR DESCRIPTION
# Description
- Problem description: when using aws as an osbuild server the resulting iso/kickstart would have an internal not routable ipadress so the system could not access it. 
- Added support for aws var to be set that will get the public facing ip address when using aws ec2 as osbuild server

FIXES: <!-- AAP-NNNN -->

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor
