### PR TITLE
AAP-13348 Fix UnknownUUID ID is not a valid uuid

### DIFF
--- a/changelogs/fragments/217-fix-remove-id-not-valid-uuid.yaml
+++ b/changelogs/fragments/217-fix-remove-id-not-valid-uuid.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - builder - Fixed remove all images from storage task when UUID is an ID.

--- a/roles/builder/tasks/main.yml
+++ b/roles/builder/tasks/main.yml
@@ -21,6 +21,7 @@
       ansible.builtin.command: "/usr/bin/composer-cli compose delete {{ (item | split)[0] }}"
       loop: "{{ builder_output.stdout_lines }}"
       changed_when: true
+      when: (item | split)[0] != "ID"
 
 - name: Get current image storage size
   block:


### PR DESCRIPTION
# Description
Cannot cleanup images because UnknownUUID ID is not a valid UUID.
This change fixes it.

See the logs:
```
TASK [infra.osbuild.builder : Get all images for removal] **********************
ok: [test -> osbuild_builder] => {"changed": false, "cmd": ["/usr/bin/composer-cli", "compose", "list"], "delta": "0:00:00.104799", "end": "2023-06-16 16:39:00.898048", "msg": "", "rc": 0, "start": "2023-06-16 16:39:00.793249", "stderr": "", "stderr_lines": [], "stdout": "ID   Status   Blueprint   Version   Type", "stdout_lines": ["ID   Status   Blueprint   Version   Type"]}
TASK [infra.osbuild.builder : Remove each image by UUID] ***********************
failed: [test -> osbuild_builder] (item=ID   Status   Blueprint   Version   Type) => {"ansible_loop_var": "item", "changed": true, "cmd": ["/usr/bin/composer-cli", "compose", "delete", "ID"], "delta": "0:00:00.010980", "end": "2023-06-16 16:39:01.652168", "item": "ID   Status   Blueprint   Version   Type", "msg": "non-zero return code", "rc": 1, "start": "2023-06-16 16:39:01.641188", "stderr": "ERROR: UnknownUUID: ID is not a valid uuid", "stderr_lines": ["ERROR: UnknownUUID: ID is not a valid uuid"], "stdout": "", "stdout_lines": []} 
```

FIXES: [AAP-13348](https://issues.redhat.com/browse/AAP-13348)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor
