### PR TITLE
Add timeout param to start_compose

### DIFF
--- a/changelogs/fragments/251-add-start-compose-api-timeout-argument.yml
+++ b/changelogs/fragments/251-add-start-compose-api-timeout-argument.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Add "builder_request_timeout" argument to infra.osbuild.builder

--- a/plugins/module_utils/weldrapiv1.py
+++ b/plugins/module_utils/weldrapiv1.py
@@ -279,7 +279,7 @@ class WeldrV1:
         raise NotImplementedError
 
     # Composes
-    def post_compose(self, compose_settings):
+    def post_compose(self, compose_settings, timeout=120):
         """
         initiate a compose
 
@@ -294,7 +294,7 @@ class WeldrV1:
             data=compose_settings,
             headers={"Content-Type": "application/json"},
             unix_socket=self.weldr.unix_socket,
-            timeout=120,
+            timeout=timeout,
         )
         result = dict()
         result["status_code"] = info["status"]

--- a/plugins/modules/start_compose.py
+++ b/plugins/modules/start_compose.py
@@ -273,7 +273,9 @@ def start_compose(module, weldr):
                     if submitted_compose_found_failed:
                         submitted_compose_uuid: str = submitted_compose_found_failed[0]["id"]
                     else:
-                        module.fail_json(msg="Unable to determine state of build, check osbuild-composer system logs")
+                        module.fail_json(
+                            msg="Unable to determine state of build, check osbuild-composer system logs. Also, consider increasing the request timeout"
+                        )
 
             if submitted_compose_uuid:
                 result: dict = weldr.api.get_compose_status(submitted_compose_uuid)

--- a/plugins/modules/start_compose.py
+++ b/plugins/modules/start_compose.py
@@ -91,6 +91,12 @@ options:
         type: str
         default: ""
         required: false
+    timeout:
+        description:
+            - timeout for osbuild-compose requests, in seconds
+        type: int
+        default: 120
+        required: false
 notes:
     - THIS MODULE IS NOT IDEMPOTENT UNLESS C(allow_duplicate) is set to C(false)
     - The params C(profile) and C(image_name) are required together.
@@ -150,6 +156,7 @@ argument_spec = dict(
     ostree_ref=dict(type="str", required=False, default=""),
     ostree_parent=dict(type="str", required=False, default=""),
     ostree_url=dict(type="str", required=False, default=""),
+    timeout=dict(type="int", required=False, default=120),
 )
 
 
@@ -224,7 +231,7 @@ def start_compose(module, weldr):
             }
 
         try:
-            result: dict = weldr.api.post_compose(json.dumps(compose_settings))
+            result: dict = weldr.api.post_compose(json.dumps(compose_settings), timeout=module.params["timeout"])
         except socket.timeout:
             # it's possible we don't get a response back from weldr because on the
             # very first run including a new content source composer will build a repo cache

--- a/roles/builder/defaults/main.yml
+++ b/roles/builder/defaults/main.yml
@@ -23,3 +23,4 @@ builder_compose_customizations:
 builder_image_storage_threshold: 3  # percentage
 builder_image_storage_cleared: false
 builder_system_ipv4: "{{ ansible_default_ipv4.address }}"
+builder_request_timeout: 120

--- a/roles/builder/meta/argument_specs.yaml
+++ b/roles/builder/meta/argument_specs.yaml
@@ -147,3 +147,9 @@ argument_specs:
       builder_aap_ks_password:
         type: "str"
         required: false
+
+      builder_request_timeout:
+        type: "int"
+        required: false
+        default: 120
+        description: "Optionally, set OSBuild composer API timeout in seconds"

--- a/roles/builder/meta/argument_specs.yaml
+++ b/roles/builder/meta/argument_specs.yaml
@@ -152,4 +152,6 @@ argument_specs:
         type: "int"
         required: false
         default: 120
-        description: "Optionally, set OSBuild composer API timeout in seconds"
+        description: |
+          Optionally, set OSBuild composer API timeout in seconds.
+          This can be useful if a compose request times out while waiting for osbuild-composer service to respond on slow machines.

--- a/roles/builder/tasks/main.yml
+++ b/roles/builder/tasks/main.yml
@@ -115,6 +115,7 @@
           infra.osbuild.start_compose:  # noqa only-builtins
             blueprint: "{{ builder_blueprint_name }}"
             compose_type: "{{ _builder_compose_type }}"
+            timeout: "{{ builder_request_timeout }}"
           register: builder_compose_start_out
 
         - name: Wait for compose to finish
@@ -252,6 +253,7 @@
         compose_type: "{{ builder_compose_type }}"
         ostree_url: "{{ builder_ostree_url if builder_ostree_url is defined else 'http://' + builder_system_ipv4 + '/' + builder_blueprint_name + '/repo/' }}"  # noqa yaml[line-length]
         ostree_ref: "{{ builder_blueprint_ref | default(omit) }}"
+        timeout: "{{ builder_request_timeout }}"
       register: builder_compose_start_out
       when:
         - "'edge' not in builder_compose_type and 'iot' not in builder_compose_type"
@@ -262,6 +264,7 @@
         compose_type: "{{ builder_compose_type }}"
         ostree_url: "{{ builder_ostree_url if builder_ostree_url is defined else 'http://' + builder_system_ipv4 + '/' + builder_blueprint_name + '/repo/' }}"  # noqa yaml[line-length]
         ostree_ref: "{{ builder_blueprint_ref | default(omit) }}"
+        timeout: "{{ builder_request_timeout }}"
       register: builder_compose_start_out
       when:
         - "'edge' in builder_compose_type or 'iot' in builder_compose_type"

--- a/tests/unit/plugins/modules/test_start_compose.py
+++ b/tests/unit/plugins/modules/test_start_compose.py
@@ -28,6 +28,7 @@ args = {
     "ostree_ref": "",
     "ostree_parent": "",
     "ostree_url": "",
+    "timeout": 60,
 }
 
 


### PR DESCRIPTION
# Description

On first run after an osbuild-composer host has been set up , an OSBuild Composer API (Weldr) request may time out because of the systemd services still starting up. Setting a timeout value allows to tweak this behavior and avoid timeouts on slower build hosts.

FIXES: #182

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

## Checklist

- [x] Added changelog fragment
- [x] Tests exist for affected features covering positive and negative scenarios
