### PR TITLE
added populate aap vars

### DIFF
--- a/roles/populate_aap/README.md
+++ b/roles/populate_aap/README.md
@@ -25,6 +25,27 @@ None
 |`populate_aap_credentials`|None|no|list|Use to populate AAP with credentials. More information can be found in [Configuration Collection credentials role README](https://github.com/redhat-cop/controller_configuration/tree/devel/roles/credentials)|<pre>populate_aap_credentials:<br>  - name: osbuild_credential<br>    organization: Osbuild_test<br>    credentail_type: Machine<br>    inputs:<br>      username: user<br>      ssh_key_data: "{{ lookup('file', '~/.ssh/id_rsa_aap', errors='warn') }}" </pre>|
 |`populate_aap_job_templates`|None|no|list|Use to populate AAP with job templates. More information can be found in [Configuration Collection job templates role README](https://github.com/redhat-cop/controller_configuration/tree/devel/roles/job_templates)|<pre>populate_aap_job_templates:<br>  - name: osbuild_setup_server<br>      job_type: run<br>      inventory: osbuild_inventory<br>      project: osbuild_project<br>      playbook: playbooks/<br>      osbuild_setup_server.yml<br>      credentials:<br>        - osbuild_credential</pre>|
 
+### populate_aap_default_host_user
+
+Type: string
+Required: false
+
+Default host user for the remote system.
+
+### populate_aap_default_host_ip
+
+Type: string
+Required: false
+
+Default ip for the remote system.
+
+### populate_aap_ssh_key_path
+
+Type: string
+Required: false
+
+Path to the private ssh key that will be used for communication remote systems.
+
 ## Variables Exported by the Role
 
 None.

--- a/roles/populate_aap/defaults/main.yml
+++ b/roles/populate_aap/defaults/main.yml
@@ -9,6 +9,8 @@ populate_aap_execution_environment_name: osbuild_ee
 populate_aap_inventory_name: osbuild_inventory
 populate_aap_project_name: osbuild_project
 populate_aap_credential_name: osbuild_credential
+populate_aap_default_host_user: user
+populate_aap_default_host_ip: 0.0.0.0
 populate_aap_organizations:
   - name: "{{ populate_aap_organization_name }}"
 populate_aap_execution_environments:
@@ -23,8 +25,8 @@ populate_aap_hosts:
   - name: osbuild_remote_system
     inventory: "{{ populate_aap_inventory_name }}"
     variables:
-      ansible_host: 0.0.0.0
-      ansible_user: user
+      ansible_host: "{{ populate_aap_default_host_ip }}"
+      ansible_user: "{{ populate_aap_default_host_user }}"
 populate_aap_projects:
   - name: "{{ populate_aap_project_name }}"
     organization: "{{ populate_aap_organization_name }}"
@@ -36,8 +38,8 @@ populate_aap_credentials:
     organization: "{{ populate_aap_organization_name }}"
     credential_type: Machine
     inputs:
-      username: user
-      ssh_key_data: "{{ lookup('file', '/home/user/.ssh/id_rsa') }}"
+      username: "{{ populate_aap_default_host_user }}"
+      ssh_key_data: "{{ lookup('file', populate_aap_ssh_key_path) if populate_aap_ssh_key_path is defined else '' }}"
 populate_aap_job_templates:
   - name: osbuild_setup_server
     job_type: run
@@ -57,7 +59,6 @@ populate_aap_job_templates:
     ask_variables_on_launch: true
     extra_vars:
       _docs: 'REPLACE WITH VARS FROM DOCS: https://github.com/redhat-cop/infra.osbuild/blob/main/roles/builder/APP_EXTRA_VARS.md'  # yamllint disable-line rule:line-length
-
     credentials:
       - "{{ populate_aap_credential_name }}"
 

--- a/roles/populate_aap/tasks/main.yml
+++ b/roles/populate_aap/tasks/main.yml
@@ -193,7 +193,7 @@
     name: redhat_cop.controller_configuration.organizations
   when: controller_organizations is defined
 
-- name: Configure execution enviornment for AAP
+- name: Configure execution environment for AAP
   ansible.builtin.include_role:
     name: redhat_cop.controller_configuration.execution_environments
   when: controller_execution_environments is defined


### PR DESCRIPTION
# Description
- Changed the interface for populating aap with ssh keys and default user/ip. This way the user can run the role without having to edit defaults.
- Also gives an easier interface to provide correct info.
- Updated docs


FIXES: <!-- AAP-NNNN -->
#213 
## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

## Checklist

- [ ] Added changelog fragment
- [ ] Tests exist for affected features covering positive and negative scenarios
