### PR TITLE
AAP-12547 prefer podman in ansible-test

### DIFF
--- a/changelogs/fragments/262-AAP-12547-prefer-podman-in-ansible-test.yml
+++ b/changelogs/fragments/262-AAP-12547-prefer-podman-in-ansible-test.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Prefer podman in ansible-test

--- a/tests/utils/shippable/shippable.sh
+++ b/tests/utils/shippable/shippable.sh
@@ -141,6 +141,8 @@ else
     timeout=50
 fi
 
+export ANSIBLE_TEST_PREFER_PODMAN=1
+
 ansible-test env --dump --show --timeout "${timeout}" --color -v
 
 "tests/utils/shippable/${script}.sh" "${test}" "${ansible_version}"


### PR DESCRIPTION
# Description

For ansible-test, prefer podman over docker

FIXES: AAP-12547 (partial)

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [X] Refactor

## Checklist

- [x] Added changelog fragment
- [ ] Tests exist for affected features covering positive and negative scenarios
