### PR TITLE
fix: concatenate lists without embedding into an outer layer of list

### DIFF
--- a/changelogs/fragments/308-fix-start_compose-idempotency.yaml
+++ b/changelogs/fragments/308-fix-start_compose-idempotency.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - concatenate lists without embeddeding into an outer layer of list in start_compose to restore idempotent operation

--- a/plugins/modules/start_compose.py
+++ b/plugins/modules/start_compose.py
@@ -212,7 +212,7 @@ def start_compose(module, weldr):
             if (compose["blueprint"] == module.params["blueprint"]) and (compose["version"] == blueprint_version)
         ]
 
-        dupe_compose: list = [compose_queue_run_dupe + compose_queue_new_dupe + compose_failed_dupe + compose_finished_dupe]
+        dupe_compose: list = compose_queue_run_dupe + compose_queue_new_dupe + compose_failed_dupe + compose_finished_dupe
 
     if module.params["allow_duplicate"] or (len(dupe_compose) == 0):
         # FIXME - build to POST payload and POST that ish

--- a/tests/unit/plugins/modules/test_start_compose.py
+++ b/tests/unit/plugins/modules/test_start_compose.py
@@ -68,6 +68,22 @@ def test_start_compose_submitted_queue():
     assert "Compose submitted to queue" in str(exit_json_obj)
 
 
+def test_start_compose_submitted_duplicate_allowed():
+    module = mock_module(args)
+    weldr = mock_weldr()
+
+    # Have to change the version of the return status to match the "running"
+    #   blueprints in the mock.
+    get_blueprint_info_mock = deepcopy(get_blueprint_info_mock_global)
+    get_blueprint_info_mock["blueprints"][0]["version"] = "0.0.5"
+    weldr.api.get_blueprints_info = Mock(return_value=get_blueprint_info_mock)
+
+    with pytest.raises(AnsibleExitJson) as exit_json_obj:
+        start_compose(module, weldr=weldr)
+    # We expect this to work unless we set allow_duplicate to False
+    assert "Compose submitted to queue" in str(exit_json_obj)
+
+
 def test_start_compose_submitted_duplicate():
     args["allow_duplicate"] = False
     module = mock_module(args)


### PR DESCRIPTION
Fixes: #307

# Description

Concatenate lists using the `+` operator without encapsulating with an outer layer of list, since the length of the sum of the lists is the most important characteristic

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Tests update
- [ ] Refactor

## Checklist

- [x] Added changelog fragment
- [x] Tests exist for affected features covering positive and negative scenarios
