### PR TITLE
Fix: start_compose changed report valid changed depending on whether or not compose was started

### DIFF
--- a/changelogs/fragments/310-fix-start_compose-changed.yaml
+++ b/changelogs/fragments/310-fix-start_compose-changed.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - return changed bool in response json from start_compose module

--- a/plugins/modules/rhsm_repo_info.py
+++ b/plugins/modules/rhsm_repo_info.py
@@ -36,7 +36,7 @@ EXAMPLES = """
 - name: Add source for custom packages
   infra.osbuild.rhsm_repo_info:
     name:
-     - rhocp-ironic-4.12-for-rhel-8-x86_64-rpms
+      - rhocp-ironic-4.12-for-rhel-8-x86_64-rpms
   register: rhsm_repo_info_out
 
 - name: Debug rhsm_repo_info_out

--- a/plugins/modules/start_compose.py
+++ b/plugins/modules/start_compose.py
@@ -292,8 +292,9 @@ def start_compose(module, weldr):
                     msg="Compose returned body: {0}, msg {1}, and status_code {2}".format(result["body"], result["error_msg"], result["status_code"]),
                     changed=changed
                 )
-            # Having received a non-400+ response, we know a compose has started
-            changed: bool = True
+
+        # Having received a non-400+ response, we know a compose has started
+        changed: bool = True
 
         compose_output_types: dict[str, list[str]] = {
             "tar": ["tar", "edge-commit", "iot-commit", "edge-container", "iot-container", "container"],

--- a/plugins/modules/start_compose.py
+++ b/plugins/modules/start_compose.py
@@ -174,13 +174,15 @@ def start_compose(module, weldr):
     if not is_supported:
         module.fail_json(
             msg="%s is not a valid image type, valid types are: %s"
-            % (module.params["compose_type"], [[v for k, v in t.items() if k == "name"] for t in supported_compose_type["types"]])
+            % (module.params["compose_type"], [[v for k, v in t.items() if k == "name"] for t in supported_compose_type["types"]]),
+            changed=changed
         )
     else:
         if not is_supported["enabled"]:
             module.fail_json(
                 msg="%s is not a supported image type, supported image types are: %s"
-                % (module.params["compose_type"], [[v for k, v in t.items() if k == "enabled" and v is True] for t in supported_compose_type["types"]])
+                % (module.params["compose_type"], [[v for k, v in t.items() if k == "enabled" and v is True] for t in supported_compose_type["types"]]),
+                changed=changed
             )
 
     if not module.params["allow_duplicate"]:
@@ -274,7 +276,8 @@ def start_compose(module, weldr):
                         submitted_compose_uuid: str = submitted_compose_found_failed[0]["id"]
                     else:
                         module.fail_json(
-                            msg="Unable to determine state of build, check osbuild-composer system logs. Also, consider increasing the request timeout"
+                            msg="Unable to determine state of build, check osbuild-composer system logs. Also, consider increasing the request timeout",
+                            changed=changed
                         )
 
             if submitted_compose_uuid:
@@ -286,8 +289,11 @@ def start_compose(module, weldr):
         if "status_code" in result.keys():
             if result["status_code"] >= 400:
                 module.fail_json(
-                    msg="Compose returned body: {0}, msg {1}, and status_code {2}".format(result["body"], result["error_msg"], result["status_code"])
+                    msg="Compose returned body: {0}, msg {1}, and status_code {2}".format(result["body"], result["error_msg"], result["status_code"]),
+                    changed=changed
                 )
+            # Having received a non-400+ response, we know a compose has started
+            changed: bool = True
 
         compose_output_types: dict[str, list[str]] = {
             "tar": ["tar", "edge-commit", "iot-commit", "edge-container", "iot-container", "container"],
@@ -305,7 +311,7 @@ def start_compose(module, weldr):
                 output_type: str = compose_type
         result["output_type"] = output_type
 
-        module.exit_json(msg="Compose submitted to queue", result=result)
+        module.exit_json(msg="Compose submitted to queue", result=result, changed=changed)
 
     else:
         changed: bool = False

--- a/tests/unit/plugins/modules/test_start_compose.py
+++ b/tests/unit/plugins/modules/test_start_compose.py
@@ -40,6 +40,7 @@ def test_start_compose_not_valid_image_type():
     with pytest.raises(AnsibleFailJson) as fail_json_obj:
         start_compose(module, weldr=weldr)
     assert "not a valid image type" in str(fail_json_obj)
+    assert not fail_json_obj.value.args[0]['changed']
 
 
 def test_start_compose_not_supported_image_type():
@@ -49,6 +50,7 @@ def test_start_compose_not_supported_image_type():
     with pytest.raises(AnsibleFailJson) as fail_json_obj:
         start_compose(module, weldr=weldr)
     assert "not a supported image type" in str(fail_json_obj)
+    assert not fail_json_obj.value.args[0]['changed']
 
 
 def test_start_compose_unable_to_determine_build():
@@ -58,6 +60,7 @@ def test_start_compose_unable_to_determine_build():
     with pytest.raises(AnsibleFailJson) as fail_json_obj:
         start_compose(module, weldr=weldr)
     assert "Unable to determine state of build" in str(fail_json_obj)
+    assert not fail_json_obj.value.args[0]['changed']
 
 
 def test_start_compose_submitted_queue():
@@ -66,6 +69,7 @@ def test_start_compose_submitted_queue():
     with pytest.raises(AnsibleExitJson) as exit_json_obj:
         start_compose(module, weldr=weldr)
     assert "Compose submitted to queue" in str(exit_json_obj)
+    assert exit_json_obj.value.args[0]['changed']
 
 
 def test_start_compose_submitted_duplicate_allowed():
@@ -82,6 +86,7 @@ def test_start_compose_submitted_duplicate_allowed():
         start_compose(module, weldr=weldr)
     # We expect this to work unless we set allow_duplicate to False
     assert "Compose submitted to queue" in str(exit_json_obj)
+    assert exit_json_obj.value.args[0]['changed']
 
 
 def test_start_compose_submitted_duplicate():
@@ -98,3 +103,4 @@ def test_start_compose_submitted_duplicate():
     with pytest.raises(AnsibleExitJson) as exit_json_obj:
         start_compose(module, weldr=weldr)
     assert "Not queuing a duplicate versioned" in str(exit_json_obj)
+    assert not exit_json_obj.value.args[0]['changed']


### PR DESCRIPTION
# Description

Return change status in response of start_compose module to enable idempotency

FIXES: #309 

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [x] Tests update
- [ ] Refactor

## Checklist

- [x] Added changelog fragment
- [x] Tests exist for affected features covering positive and negative scenarios
