### PR TITLE
include blueprint import file option

### DIFF
--- a/roles/builder/README.md
+++ b/roles/builder/README.md
@@ -221,6 +221,22 @@ Example:
 builder_pub_key: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDA8mSWJrMW9PSy3gXpqTu/QQPB/gfahwLIvt007poNHRartDaLQPNOwfGzBRXXaaP5RVAHqwmxStP3eVkIdm1UhzJ1X50KCWz5Oq0PW2UGjxCxdgutNbBEtGqewR9N7jOulcEjV+JQG1//vSuLlPWm/5W3nAE6objc+YQ1RyBSqgN58pvvqfhh2kjBKxAS1urDSc0CUlhefWnV60dYY7dApHemEC/+XZbYP68bVznZVPf4k0s+0Tx1GAxDMxUWUj4owldO6XVwxYkEgTBaMllSYyT95Mq6wqFQZ/k3IKikczwKnqsjFTl3/AFMaWgGlyGurCrKZtPEpZVsZYLlgWUtoZWlbUJHiKgyn4V8ErHVZBzauOkyydTaBp0O2ZxOTvIWlCkzR9129hxK4C2u0eewAfw0m1x8C2sB9OboteWpVFSIKXUb9he72lDguR8rfoTrvMwYKQ27z4FQbLQeAt4I1hPY/7bL4UYnKMszpmV7GuAPfzwtz0tBt2C4uX4b7OE= resolutecoder@fedora
 ```
 
+
+### builder_blueprint_import_file
+
+Type: string
+Required: false
+
+Local path to the blueprint TOML file that will be used. That will be done instead of creating a new blueprint using the `builder_compose_pkgs` and `builder_compose_customizations` variables. The Blueprint name will be overwritten by the `builder_blueprint_name` variable.
+
+Example:
+
+```yaml
+builder_blueprint_import_file: "~/microshift-embedded.toml"
+```
+
+
+
 ### builder_compose_pkgs
 
 Type: list

--- a/roles/builder/meta/argument_specs.yaml
+++ b/roles/builder/meta/argument_specs.yaml
@@ -101,7 +101,7 @@ argument_specs:
         description: "SSH public key to inject into the resulting image to allow key-based ssh functionality without extra configuration for systems installed with the resulting build media."  # yamllint disable-line rule:line-length
 
       builder_blueprint_import_file:
-        type: "string"
+        type: "str"
         required: false
         description: "Blueprint file to be imported."
 

--- a/roles/builder/meta/argument_specs.yaml
+++ b/roles/builder/meta/argument_specs.yaml
@@ -100,6 +100,11 @@ argument_specs:
         required: false
         description: "SSH public key to inject into the resulting image to allow key-based ssh functionality without extra configuration for systems installed with the resulting build media."  # yamllint disable-line rule:line-length
 
+      builder_blueprint_import_file:
+        type: "string"
+        required: false
+        description: "Blueprint file to be imported."
+
       builder_compose_pkgs:
         type: "list"
         required: false

--- a/roles/builder/tasks/main.yml
+++ b/roles/builder/tasks/main.yml
@@ -122,7 +122,11 @@
               builder_blueprint_output:
                 msg: "Blueprint file written to location: {{ builder_blueprint_src_path }}"
                 changed: true
-                current_version: "{{ _imported_blueprint_version }}"
+                current_version: "{{ _imported_blueprint_version.stdout }}"
+
+          - name: Show generated variable
+            debug:
+              var: builder_blueprint_output
           when: builder_blueprint_import_file is defined
 
         - name: Push the blueprint into image builder

--- a/roles/builder/tasks/main.yml
+++ b/roles/builder/tasks/main.yml
@@ -93,9 +93,37 @@
             dest: "{{ builder_blueprint_src_path }}"
             name: "{{ builder_blueprint_name }}"
             distro: "{{ builder_blueprint_distro | default(omit) }}"
-            packages: "{{ builder_compose_pkgs }}"
-            customizations: "{{ builder_compose_customizations }}"
+            packages: "{{ builder_compose_pkgs  | default(omit) }}"
+            customizations: "{{ builder_compose_customizations  | default(omit) }}"
           register: builder_blueprint_output
+          when: builder_blueprint_import_file is not defined
+
+        - block:
+          - name: Copy the blueprint file
+            copy:
+              src: "{{ builder_blueprint_import_file }}"
+              dest: "{{ builder_blueprint_src_path }}"
+
+          ## TODO: Check the imported file TOML format
+          - name: Read the content of the TOML file
+            slurp:
+              src: "{{ builder_blueprint_src_path }}"
+            register: toml_file_content
+
+          - name: Parse TOML content
+            shell: "echo '{{ toml_file_content.content | b64decode }}' | python -c 'import sys, toml; print(toml.loads(sys.stdin.read())[\"version\"])'"
+            register: _imported_blueprint_version
+
+          - name: Set blueprint name in the imported TOML file
+            shell: "sed -i '0,/name =/ s/name =.*/name = \"{{ builder_blueprint_name }}\"/' {{ builder_blueprint_src_path }}"
+
+          - name: Set expected var output with current_version from TOML
+            set_fact:
+              builder_blueprint_output:
+                msg: "Blueprint file written to location: {{ builder_blueprint_src_path }}"
+                changed: true
+                current_version: "{{ _imported_blueprint_version }}"
+          when: builder_blueprint_import_file is defined
 
         - name: Push the blueprint into image builder
           infra.osbuild.push_blueprint:  # noqa only-builtins


### PR DESCRIPTION
# Description

This is the first approach to cover [1]. I didn't modify any module, I just added a new `builder_blueprint_import_file` variable. If the variable is defined, then it copies the file into the image builder, and then pushes that blueprint instead of creating the blueprint from the vars.

[1] https://github.com/redhat-cop/infra.osbuild/issues/225

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

## Checklist

- [ ] Added changelog fragment
- [ ] Tests exist for affected features covering positive and negative scenarios
