### PR TITLE
Small typos in readmes and fix required

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ ansible-playbook playbooks/osbuild_setup_server.yml
 ansible-playbook playbooks/osbuild_builder.yml
 ```
 
-You can specify what kind of build you prefer with the variable buidler_compose_type.
+You can specify what kind of build you prefer with the variable `builder_compose_type`.
 
 Current supported and tested build types are:
 
@@ -156,4 +156,4 @@ ansible-test units --docker --python $PYTHON_VERSION $TEST_FILE_PATH
 ansible-test integration --remote rhel/$RHEL_VERSION $IMAGE_TYPE
 ```
 ## Known issues
-- rpm-ostree may crash when trying to run the `rpm-ostree upgrade --check` command. This is caused by an open issue in rpm-ostee found here: https://github.com/coreos/rpm-ostree/issues/4280
+- rpm-ostree may crash when trying to run the `rpm-ostree upgrade --check` command. This is caused by an open issue in rpm-ostree found here: https://github.com/coreos/rpm-ostree/issues/4280

--- a/roles/builder/README.md
+++ b/roles/builder/README.md
@@ -93,7 +93,7 @@ This is the name of the [osbuild blueprint](https://www.osbuild.org/guides/bluep
 to use. The blueprint will be auto generated based on the contents of the
 `builder_compose_customizations` role variable. In the event an of an [rpm-ostree](https://rpm-ostree.readthedocs.io/en/stable/)
 based compose type specified by the `builder_compose_type` role variable, the
-blueprint name defined in this variable will use used to define the resulting [ostree](https://ostreedev.github.io/ostree/)
+blueprint name defined in this variable will be used to define the resulting [ostree](https://ostreedev.github.io/ostree/)
 repository.
 
 ### builder_blueprint_src_path
@@ -165,7 +165,7 @@ builder_wait_compose_timeout: 2400
 ### builder_enforce_auth
 
 Type: bool
-Required: true
+Required: false
 
 Enforces system authentication using public ssh keys or user password
 

--- a/roles/builder/meta/argument_specs.yaml
+++ b/roles/builder/meta/argument_specs.yaml
@@ -82,7 +82,8 @@ argument_specs:
 
       builder_enforce_auth:
         type: "str"
-        required: true
+        required: false
+        default: true
         description: "Enforces system authentication using public ssh keys or user password."
 
       builder_password:

--- a/roles/setup_server/README.md
+++ b/roles/setup_server/README.md
@@ -78,7 +78,7 @@ setup_server_rhsatellite_contentview: "RHEL_8"
 ### setup_server_beta_repos
 
 Type: boolean
-Required: true
+Required: false
 
 This variable is used to setup beta repositories for appstream and baseos, set true to setup beta repositories and false to setup non-beta repositories.
 


### PR DESCRIPTION
# Description

Few documentation typos and according to https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_reuse_roles.html#specification-format variables with a default can't be required

## Type of change

What is it?

- [x] Documentation update


## Checklist

- [ ] Added changelog fragment
- [x] Tests exist for affected features covering positive and negative scenarios