### PR TITLE
Add ignition to simplified installer blueprint

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,15 @@ Infra.Osbuild Release Notes
 
 .. contents:: Topics
 
+v2.3.1
+======
+
+Minor Changes
+-------------
+
+- Include blueprint import file option
+- Add ignition to simplified installer blueprint
+
 v2.3.0
 ======
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -10,7 +10,7 @@ namespace: infra
 name: osbuild
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 2.3.0
+version: 2.3.1
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/builder/tasks/main.yml
+++ b/roles/builder/tasks/main.yml
@@ -264,10 +264,10 @@
           ansible.builtin.set_fact:
             __simplified_insaller_customizations: {}
 
-        - name: Set __simplified_insaller_customizations value including only fdo and installation_device customizations
+        - name: Set __simplified_insaller_customizations value including only fdo, ignition and installation_device customizations
           ansible.builtin.set_fact:
             __simplified_insaller_customizations: "{{ __simplified_insaller_customizations | combine({item.key: item.value}) }}"
-          when: "item.key in ['fdo', 'installation_device']"
+          when: "item.key in ['fdo', 'installation_device', 'ignition']"
           with_dict: "{{ builder_compose_customizations }}"
 
         - name: Create simplified installer blueprint


### PR DESCRIPTION
# Description

We need to be able to include ignition definition for simplified installer images


