### PR TITLE
Update extra-docs-linting.yml

### DIFF
--- a/.github/workflows/extra-docs-linting.yml
+++ b/.github/workflows/extra-docs-linting.yml
@@ -31,6 +31,9 @@ jobs:
           python-version: "3.10"
 
       - name: Install antsibull-docs
+        run: ansible-galaxy collection install fedora.linux_system_roles
+
+      - name: Install antsibull-docs
         run: pip install antsibull-docs --disable-pip-version-check
 
       - name: Run collection docs linter


### PR DESCRIPTION
Adding fedora collection

# Description
- Fixes issue with CI failing 
RuntimeError: The command
| ansible-doc -vvv --metadata-dump --no-fail-on-errors amazon.aws ansible.builtin ansible.posix fedora.linux_system_roles infra.osbuild
returned exit status 1 with error output:
| ERROR! Cannot use supplied collection fedora.linux_system_roles: unable to locate collection fedora.linux_system_roles. unable to locate collection fedora.linux_system_roles

FIXES:  CI Workflow

## Type of change

What is it?

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

## Checklist

- [ ] Added changelog fragment
- [ ] Tests exist for affected features covering positive and negative scenarios
