### PR TITLE
Add FIPS support to ISO installer

### DIFF
--- a/roles/builder/tasks/main.yml
+++ b/roles/builder/tasks/main.yml
@@ -248,11 +248,22 @@
     - builder_compose_type is defined
     - "'installer' in builder_compose_type or 'raw' in builder_compose_type"
   block:
+    - name: Create __edge_insaller_customizations var
+      ansible.builtin.set_fact:
+        __edge_insaller_customizations: {}
+
+    - name: Set _edge_insaller_customizations value including only fdo and installation_device customizations
+      ansible.builtin.set_fact:
+        __edge_insaller_customizations: "{{ __edge_insaller_customizations | combine({item.key: item.value}) }}"
+      when: "item.key in ['fips']"
+      with_dict: "{{ builder_compose_customizations }}"
+
     - name: Create blank blueprint
       infra.osbuild.create_blueprint:  # noqa only-builtins
         dest: "{{ builder_blueprint_src_path }}"
         name: "{{ builder_blueprint_name }}-empty"
         distro: "{{ builder_blueprint_distro | default(omit) }}"
+        customizations: "{{ __edge_insaller_customizations }}"
       register: __builder_blueprint_output  # noqa var-naming[no-role-prefix]
       when:
         - "'simplified' not in builder_compose_type and 'edge' in builder_compose_type or 'iot' in builder_compose_type"


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

As more enterprises adopt OSBuild images for their OS deployments, they will require more security features.  One such feature is running OSBuild OS's in FIPS mode.  This small patch allows the ability to create ISO installers that run in FIPS mode.  

FIXES: <!-- AAP-NNNN -->

## Type of change

What is it?

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

## Checklist

- [ ] Added changelog fragment
- [ ] Tests exist for affected features covering positive and negative scenarios
