### PR TITLE
Fix logic so the task doesn't fail incorrectly when Satellite is installed

### DIFF
--- a/roles/setup_server/tasks/setup_rh_satellite_repos.yml
+++ b/roles/setup_server/tasks/setup_rh_satellite_repos.yml
@@ -7,7 +7,7 @@
 - name: Error message if Satellite is missing
   ansible.builtin.fail:
     msg: "Satellite not found, please ensure Satallite is configured properly"
-  when: katello_file.stat.exists
+  when: not katello_file.stat.exists
 
 - name: Debug
   ansible.builtin.debug:


### PR DESCRIPTION
# Description

This commit fixes the logic on the `Error message if Satellite is missing` task so that it doesn't fail when the Katello server certificate exists.

FIXES: [449](https://github.com/redhat-cop/infra.osbuild/issues/449)

## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

## Checklist

- [ ] Added changelog fragment
- [ ] Tests exist for affected features covering positive and negative scenarios
