### PR TITLE
Fix: Creating edge-commit to update the ostree repo will now refer to the existing ostree commit rather than building a independent commit

### DIFF
--- a/changelogs/fragments/313-edge-commit-should-update-existing-ostee-repo.yaml
+++ b/changelogs/fragments/313-edge-commit-should-update-existing-ostee-repo.yaml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - creating edge-commit to update the ostree repo will now refer to the existing ostree commit rather than building a independent commit, closes #477
+  - creating edge-commit to update the ostree repo will now refer to the existing ostree commit rather than building an independent commit, closes #477

--- a/changelogs/fragments/313-edge-commit-should-update-existing-ostee-repo.yaml
+++ b/changelogs/fragments/313-edge-commit-should-update-existing-ostee-repo.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - creating edge-commit to update the ostree repo will now refer to the existing ostree commit rather than building a independent commit, closes #477

--- a/plugins/modules/start_compose.py
+++ b/plugins/modules/start_compose.py
@@ -227,7 +227,7 @@ def start_compose(module, weldr):
             "size": module.params["size"],
         }
 
-        if "installer" in module.params["compose_type"] or "raw" in module.params["compose_type"]:
+        if "installer" in module.params["compose_type"] or "raw" in module.params["compose_type"] or "edge-commit" in module.params["compose_type"]:
             compose_settings["ostree"] = {
                 "ref": module.params["ostree_ref"],
                 "parent": module.params["ostree_parent"],

--- a/roles/builder/tasks/main.yml
+++ b/roles/builder/tasks/main.yml
@@ -73,8 +73,7 @@
         mode: '0755'
         state: directory
 
-- name: Process when existing commit isn't defined in builder_ostree_url variable
-  when: builder_ostree_url is not defined
+- name: Create a new commit if builder_ostree_url is not defined and update commit if builder_ostree_url is defined
   block:
     - name: Get rhsm repos properties
       when: builder_rhsm_repos is defined
@@ -144,6 +143,8 @@
           infra.osbuild.start_compose:  # noqa only-builtins
             blueprint: "{{ builder_blueprint_name }}"
             compose_type: "{{ _builder_compose_type }}"
+            ostree_url: "{{ builder_ostree_url | default(omit) }}"  # noqa yaml[line-length]
+            ostree_ref: "{{ builder_blueprint_ref | default(omit) }}"
             timeout: "{{ builder_request_timeout }}"
           register: builder_compose_start_out
 

--- a/roles/builder/tasks/main.yml
+++ b/roles/builder/tasks/main.yml
@@ -143,7 +143,7 @@
           infra.osbuild.start_compose:  # noqa only-builtins
             blueprint: "{{ builder_blueprint_name }}"
             compose_type: "{{ _builder_compose_type }}"
-            ostree_url: "{{ builder_ostree_url | default(omit) }}"  # noqa yaml[line-length]
+            ostree_url: "{{ builder_ostree_url | default(omit) }}"
             ostree_ref: "{{ builder_blueprint_ref | default(omit) }}"
             timeout: "{{ builder_request_timeout }}"
           register: builder_compose_start_out


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Whenever we initiate a edge-commit to update existing ostree repo, its not referring to the existing ostree repo as a parent commit but instead builds an independent commit.
Due to this when we update rpm-ostree system using this repo, problems have been observed with regards to UID of the system users which are added by the rpm scriptlet since these are stored in /usr/lib/passwd which changes across the commit since the commit are now not related to each other.

This change aims to solve this problem by the follow changes,

 * Change the "if" condition in start_compose.py so that the parameters "ostree_url" and "ostree_ref" are not ignored for edge-commit

 * Added parameters "ostree_url" and "ostree_ref" to the builder role "Start compose" task such that they can be used in when updating existing commit and can be ignored when building the first commit

FIXES: <!-- AAP-NNNN  --> #477 


## Type of change

What is it?

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation update
- [ ] Tests update
- [ ] Refactor

## Checklist

- [ ] Added changelog fragment
- [ ] Tests exist for affected features covering positive and negative scenarios
